### PR TITLE
Update islandora_advanced_search.module

### DIFF
--- a/islandora_advanced_search.module
+++ b/islandora_advanced_search.module
@@ -88,7 +88,7 @@ function islandora_advanced_search_form_block_form_alter(&$form, FormStateInterf
   $condition_id = 'node_has_term';
 
   /** @var \Drupal\Core\Condition\ConditionInterface $condition */
-  $condition = $manager->createInstance($condition_id, isset($visibility[$condition_id]) ? $visibility[$condition_id] : []);
+  /*$condition = $manager->createInstance($condition_id, isset($visibility[$condition_id]) ? $visibility[$condition_id] : []);
   $form_state->set(['conditions', $condition_id], $condition);
   $condition_form = $condition->buildConfigurationForm([], $form_state);
   $condition_form['#type'] = 'details';
@@ -96,7 +96,7 @@ function islandora_advanced_search_form_block_form_alter(&$form, FormStateInterf
   $condition_form['#group'] = 'visibility_tabs';
   // Not all blocks are required to give this field.
   $condition_form['term']['#required'] = FALSE;
-  $form['visibility'][$condition_id] = $condition_form;
+  $form['visibility'][$condition_id] = $condition_form;*/
 }
 
 /**


### PR DESCRIPTION
Disabled the dependency node_has_term when move the submodule Advanced Search out of Islandora module