### PR TITLE
Searching using 'is not' when EDismax is enabled always returns no results

### DIFF
--- a/src/AdvancedSearchQuery.php
+++ b/src/AdvancedSearchQuery.php
@@ -160,9 +160,11 @@ class AdvancedSearchQuery {
       $isSearchAllFields = false;
       $fields_list = [];
 
+      if (!$isDismax) {
+        // To support negative queries we must first bring in all documents.
+        $q[] = $this->negativeQuery($terms) ? "*:*" : "";
+      }
       
-      // To support negative queries we must first bring in all documents.
-      $q[] = $this->negativeQuery($terms) ? "*:*" : "";
       $term = array_shift($terms);
       $q[] = $term->toSolrQuery($field_mapping);
 

--- a/src/AdvancedSearchQueryTerm.php
+++ b/src/AdvancedSearchQueryTerm.php
@@ -302,7 +302,8 @@ class AdvancedSearchQueryTerm {
           return $value;
         }
         else {
-          return "(" .$value . " OR " . str_replace('"', "", trim($value)) . ")";
+          $isNot = $this->getInclude() ? "" : "!";
+          return $isNot . "(" .$value . " OR " . str_replace('"', "", trim($value)) . ")";
         }
       }
       if (!$this->getInclude()) {


### PR DESCRIPTION
To reproduce error:

- Go to https://tamil.digital.utsc.utoronto.ca/collection/10673
- Enter a search using 'is not'
- The result is always no result