### PR TITLE
Check if view argument is null before function call

### DIFF
--- a/src/AdvancedSearchQuery.php
+++ b/src/AdvancedSearchQuery.php
@@ -301,9 +301,11 @@ class AdvancedSearchQuery {
             $refer->getPathInfo();
             $refer->attributes->add(\Drupal::getContainer()->get('router')->matchRequest($refer));
             $request_stack->push($refer);
-            $plugin = $view->argument[$immediate_children_contextual_filter]->getPlugin('argument_default');
-            if ($plugin) {
-              $view->args[$index] = $plugin->getArgument();
+            if (isset($view->argument[$immediate_children_contextual_filter])) {
+              $plugin = $view->argument[$immediate_children_contextual_filter]->getPlugin('argument_default');
+              if ($plugin) {
+                $view->args[$index] = $plugin->getArgument();
+              }
             }
             $request_stack->pop();
           }


### PR DESCRIPTION
**Errors**

```
Notice: Undefined index: in Drupal\advanced_search\AdvancedSearchQuery->alterView() 
(line 304 of /var/www/drupal/web/modules/contrib/advanced_search/src/AdvancedSearchQuery.php)

Error: Call to a member function getPlugin() on null in Drupal\advanced_search\AdvancedSearchQuery->alterView()
(line 304 of /var/www/drupal/web/modules/contrib/advanced_search/src/AdvancedSearchQuery.php)
```

**To reproduce**

- Install FullCalendar Solr module
- Create a view using the FullCalendar Solr view formatter
- Enable Ajax
- Go to the view and try to search using the Advanced Search block / facets
