### PR TITLE
update advanced search for new Drupal "once" function

### DIFF
--- a/advanced_search.libraries.yml
+++ b/advanced_search.libraries.yml
@@ -3,6 +3,7 @@ advanced.search.admin:
     js/advanced_search.admin.js: {}
   dependencies:
     - core/drupal.tabledrag
+    - core/once
 
 advanced.search.form:
   js:

--- a/advanced_search.libraries.yml
+++ b/advanced_search.libraries.yml
@@ -3,6 +3,7 @@ advanced.search.admin:
     js/advanced_search.admin.js: {}
   dependencies:
     - core/drupal.tabledrag
+    - core/jquery
     - core/once
 
 advanced.search.form:

--- a/js/advanced_search.admin.js
+++ b/js/advanced_search.admin.js
@@ -83,7 +83,7 @@
         updateFieldWeights(table, regionName);
       };
 
-      $(context).find('select.field-display').once('field-display').on('change', function (event) {
+      $(once('field-display', 'select.field-display', context)).on('change', function (event) {
         var row = $(this).closest('tr');
         var select = $(this);
 

--- a/js/advanced_search.form.js
+++ b/js/advanced_search.form.js
@@ -100,7 +100,7 @@
   Drupal.behaviors.advanced_search_form = {
     attach: function (context, settings) {
       if (settings.advanced_search_form.id !== 'undefined') {
-        const $form = $('form#' + settings.advanced_search_form.id).once();
+        const $form = $(once('search-form', 'form#' + settings.advanced_search_form.id));
         if ($form.length > 0) {
           window.addEventListener("pushstate", function (e) {
             $form.attr('action', window.location.pathname + window.location.search);

--- a/js/facets/facets-views-ajax.js
+++ b/js/facets/facets-views-ajax.js
@@ -171,8 +171,11 @@
             "-" +
             settings.view_display_id.replace(/_/g, "-")
           );
-          exposed_form
-            .once()
+          $(once('exposed-form',
+            "form#views-exposed-form-" +
+            settings.view_name.replace(/_/g, "-") +
+            "-" +
+            settings.view_display_id.replace(/_/g, "-")))
             .find("input[type=submit], input[type=image]")
             .not("[data-drupal-selector=edit-reset]")
             .each(function (index) {
@@ -228,8 +231,7 @@
         }
 
       // Attach behavior to pager, summary, facet links.
-      $("[data-drupal-pager-id], [data-drupal-facets-summary-id], [data-drupal-facet-id]")
-        .once()
+      $(once("new-window", "[data-drupal-pager-id], [data-drupal-facets-summary-id], [data-drupal-facet-id]"))
         .find("a:not(.facet-item)")
         .click(function (e) {
           // Let ctrl/cmd click open in a new window.
@@ -245,8 +247,7 @@
         });
 
       /* digitalutsc added */
-     $('.pager__sort select[name="order"]')
-        .once()
+      $(once('params-sort', '.pager__sort select[name="order"]'))
         .change(function () {
           var href = window.location.href;
           var params = Drupal.Views.parseQueryString(href);
@@ -263,8 +264,7 @@
 
 
       // Trigger on sort change.
-      $('[data-drupal-pager-id] select[name="order"]')
-        .once()
+      $(once('sort-change', '[data-drupal-pager-id] select[name="order"]'))
         .change(function () {
           var href = window.location.href;
           var params = Drupal.Views.parseQueryString(href);

--- a/js/facets/facets-views-ajax.js
+++ b/js/facets/facets-views-ajax.js
@@ -246,35 +246,20 @@
           window.history.pushState(null, document.title, $(this).attr("href"));
         });
 
-      /* digitalutsc added */
-      $(once('params-sort', '.pager__sort select[name="order"]'))
+      // Trigger on sort change.
+      $(once('params-sort', '[data-drupal-pager-id] select[name="order"], .pager__sort select[name="order"]'))
         .change(function () {
           var href = window.location.href;
           var params = Drupal.Views.parseQueryString(href);
 
           var selection = $(this).val();
           var option = selection.split('_');
-          //params.sort_by = option[0];
           params.sort_order = option[option.length - 1].toUpperCase();
           params.sort_by = selection.replace("_" + option[option.length - 1], "");
-
           href = href.split("?")[0] + "?" + $.param(params);
           window.history.pushState(null, document.title, href);
         });
 
-
-      // Trigger on sort change.
-      $(once('sort-change', '[data-drupal-pager-id] select[name="order"]'))
-        .change(function () {
-          var href = window.location.href;
-          var params = Drupal.Views.parseQueryString(href);
-          var selection = $(this).val();
-          var option = $('option[value="' + selection + '"]');
-          params.sort_order = option.data("sort_order");
-          params.sort_by = option.data("sort_by");
-          href = href.split("?")[0] + "?" + $.param(params);
-          window.history.pushState(null, document.title, href);
-        });
     },
   };
 })(jQuery, Drupal);

--- a/js/facets/soft-limit.js
+++ b/js/facets/soft-limit.js
@@ -43,7 +43,7 @@
 
         // Hide facets over the limit.
         facetsList.each(function () {
-            $(this).children('li:gt(' + zero_based_limit + ')').once('applysoftlimit').hide();
+            $(once('applysoftlimit', $(this).children('li:gt(' + zero_based_limit + ')'))).hide();
         });
 
 

--- a/src/Controller/AjaxBlocksController.php
+++ b/src/Controller/AjaxBlocksController.php
@@ -125,7 +125,7 @@ class AjaxBlocksController extends ControllerBase {
 
     // Rebuild the request and the current path, needed for facets.
     $path = $request->request->get('link');
-    $blocks = $request->request->get('blocks');
+    $blocks = $request->request->all('blocks');
 
     // Make sure we are not updating blocks multiple times.
     $blocks = array_unique($blocks);


### PR DESCRIPTION
# What does this Pull Request do?

Replaces calls to Jquery once with Drupal once function. 

After fixing that, we had some issues with the sorting not working. The second and third commits address this. The second commit fixes an Ajax error, and the third commit stops the function from being called twice when the sort dropdown changes. 

* **Related GitHub Issue**: (https://github.com/Islandora/advanced_search/issues/40)

* **Other Relevant Links**: 
Once replacement instructions: https://www.drupal.org/project/drupal/issues/3183149
Ajax fix: https://www.drupal.org/project/viewsreference/issues/3326841

# What's new?
There should be no changes to functionality. This just replaces some deprecated functions.

# How should this be tested?

- Create a new Drupal 10 site with the starter site.
- Add some content
- Try sorting on the search results to see JS errors in console
- Swap out advanced search for this PR and try sorting again

# Documentation Status

No documentation changes needed

# Additional Notes:
N/A

# Interested parties
@Islandora/committers
