### PR TITLE
remove need for blocks to have the 'block' class

### DIFF
--- a/js/facets/facets-views-ajax.js
+++ b/js/facets/facets-views-ajax.js
@@ -127,7 +127,7 @@
     // Replace filter, pager, summary, and facet blocks.
     var blocks = {};
     $(
-      ".block[class*='block-plugin-id--islandora-advanced-search-result-pager'], .block[class*='block-plugin-id--views-exposed-filter-block'], .block[class*='block-facets']"
+      "[class*='block-plugin-id--islandora-advanced-search-result-pager'], [class*='block-plugin-id--views-exposed-filter-block'], [class*='block-facets']"
     ).each(function () {
       var id = $(this).attr("id");
       var block_id = id


### PR DESCRIPTION
# What does this Pull Request do?

Not all themes put the 'block' class on all blocks by default. Stable9, for example, does not. This PR edits the code that reads your blocks so that it doesn't require them to have the 'block' class.

* **Other Relevant Links**: Slack discussion - https://islandora.slack.com/archives/CM5PPAV28/p1697807272573079

# How should this be tested?

Using a theme like stable9 that does not add the block class, try sorting or facetting on search results to see an Ajax error in your console. After switching to this PR that should no longer occur.

# Documentation Status

No documentation update needed

# Interested parties
@Islandora/committers
