### PR TITLE
Fixed for https://github.com/digitalutsc/advanced_search/issues/4

### DIFF
--- a/src/AdvancedSearchQueryTerm.php
+++ b/src/AdvancedSearchQueryTerm.php
@@ -320,6 +320,14 @@ class AdvancedSearchQueryTerm {
           $value = str_replace('"', "", trim($value));
         }
       }
+      // Fixed for https://github.com/digitalutsc/advanced_search/issues/4
+      if ($this->field !== "all"){
+        $search_fields = "";
+        foreach ($solr_field_mapping[$this->field] as $field) {
+            $search_fields .= " $field:$value";
+        }
+        return $search_fields;
+      }
       return $value;
     }
     else {


### PR DESCRIPTION
# What does this Pull Request do?
* It's a fix for this issue: https://github.com/Islandora/advanced_search/issues/43
* In the use case of boolean search, one condition is Keyword and one condition is Field search, as screenshot below. 

![image](https://github.com/Islandora/advanced_search/assets/7862086/3cfc2a7f-c68a-4259-8726-af0be7366d56)

* The search is ignoring the field search condition and searches as Keyword only. 

# What's new?

There is no new functionality to be added. Only add a if check to handle boolean search which is mixed with Keyword and field.

# How should this be tested?

* Apply boolean search with mixed Keyword and Field Search: 

* **Before this PR show 41 results,** 

https://sandbox.islandora.ca/search?a%5B0%5D%5Bf%5D=all&a%5B0%5D%5Bi%5D=IS&a%5B0%5D%5Bv%5D=%22wild%20flowers%22&a%5B1%5D%5Bc%5D=AND&a%5B1%5D%5Bf%5D=title_aggregated_fulltext&a%5B1%5D%5Bi%5D=IS&a%5B1%5D%5Bv%5D=Excerpt

* **After PR it show 1 results:** 

![image](https://github.com/Islandora/advanced_search/assets/7862086/6ca400b1-4d55-40d5-9852-ee5fa8c0f63b)

# Documentation Status

No needed Documentation.

# Additional Notes:
N/A


# Interested parties
@Islandora/committers
