### PR TITLE
Remove deprecated ${var} pattern.

### DIFF
--- a/src/Plugin/Block/SearchApiDisplayBlockDeriver.php
+++ b/src/Plugin/Block/SearchApiDisplayBlockDeriver.php
@@ -77,7 +77,7 @@ abstract class SearchApiDisplayBlockDeriver implements ContainerDeriverInterface
         $view_display = $display_definition['view_display'];
         // The derived block needs both the view / display identifiers to
         // construct the pager.
-        $machine_name = "${view_id}__${view_display}";
+        $machine_name = "{$view_id}__{$view_display}";
 
         /** @var \Drupal\views\ViewEntityInterface $view */
         $view = $this->storage->load($view_id);


### PR DESCRIPTION
# What does this Pull Request do?

Deprecation: https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

This removes the deprecated pattern.

# How should this be tested?


With this change, do you still get the "advanced search" and "pager" blocks for each search API view display?

# Documentation Status

* Does this change existing behaviour that's currently documented? no! 
* Does this change require new pages or sections of documentation? no!
* Who does this need to be documented for? nobody!
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
