### PR TITLE
Adding boost number for each fields for edismax query

### DIFF
--- a/src/AdvancedSearchQuery.php
+++ b/src/AdvancedSearchQuery.php
@@ -250,10 +250,25 @@ class AdvancedSearchQuery {
           }
           else {
             $query_fields = $fields_list;
-
           }
-          $query_fields = implode(" ", array_unique($query_fields));
-          $dismax->setQueryFields($query_fields);
+
+          // Get the indexed fields from /admin/config/search/search-api/index/..../fields
+          $boostedFields = [];
+          foreach ($index->getFields() as $field_id => $field) {
+              $boostedFields[$field_id] = $field->getBoost();
+          }
+          
+          $str_fields_with_boost = "";
+          // Adding a boost number for each field)
+          foreach($query_fields as $solr_field) {
+            foreach($boostedFields as $indexed_field => $boostnum) {
+                if(strpos($str_fields_with_boost, $indexed_field) == false && strpos($solr_field, $indexed_field) !== false) {
+                    $str_fields_with_boost .=  $solr_field . "^" . $boostnum . " ";
+                }
+            }
+          }
+
+          $dismax->setQueryFields($str_fields_with_boost);
         }
       }
 


### PR DESCRIPTION
# What does this Pull Request do?

For edismax solr query (https://github.com/Islandora/advanced_search/blob/2.x/src/AdvancedSearchQuery.php#L255-L256) when Advanced Search's request triggered, the list of fields which is passed to `qf=` (more on this at https://solr.apache.org/guide/solr/latest/query-guide/edismax-query-parser.html)

````
score random boost_document ss_author ds_changed ds_created itm_edtf_year .....
````

However there is no boost number which can be configured in Search API Solr index https://sandbox.islandora.ca/admin/config/search/search-api/index/default_solr_index/fields 

![Screenshot 2024-06-21 at 10 15 03 AM](https://github.com/Islandora/advanced_search/assets/7862086/22ac9942-2d7c-4276-a1ec-bd35786ac0e3)

This PR is add the code to attach the boost number for each field, for example: 

````
ss_author^1 ds_changed^1 ds_created^1 itm_edtf_year^1 sm_field_award_received^1 tm_X3b_en_field_description^8
````


# What's new?
https://github.com/digitalutsc/advanced_search/blob/kylehuynh205-patch-1/src/AdvancedSearchQuery.php#L255-L271


