### PR TITLE
Add parentheses to advanced search queries

### DIFF
--- a/src/AdvancedSearchQueryTerm.php
+++ b/src/AdvancedSearchQueryTerm.php
@@ -322,10 +322,11 @@ class AdvancedSearchQueryTerm {
       }
       // Fixed for https://github.com/digitalutsc/advanced_search/issues/4
       if ($this->field !== "all"){
-        $search_fields = "";
+        $search_fields = "(";
         foreach ($solr_field_mapping[$this->field] as $field) {
             $search_fields .= " $field:$value";
         }
+        $search_fields .= ")";
         return $search_fields;
       }
       return $value;


### PR DESCRIPTION
# What does this Pull Request do?

Adds Parentheses to search queries around each specific search field (everything but "all").

This solves an issue where multi field advanced searches don't return anything if any of the fields (except the final field) are not searching "all". This doesn't seem to be an issue in the sandbox, but it causes issues on my customized site. Adding parentheses shouldn't change the behaviour of sites that are working, but should fix the ones that aren't.

Slack conversation: https://islandora.slack.com/archives/C019U12D44Q/p1726583682481869

# What's new?
The only change is that each field searched with be wrapped in parentheses.

Previously, searching 

<img width="412" alt="image" src="https://github.com/user-attachments/assets/4401b6be-0f60-4697-8ee9-acb65f7905f5">

would create this query
q=+tm_X3b_en_title:acadia+tm_X3b_und_title:acadia+AND+acadia

But with this PR it looks like this
q=(+tm_X3b_en_title:acadia+tm_X3b_und_title:acadia)+AND+acadia

# How should this be tested?

Try a multi-field search and check the Solr log to see the query without parentheses. Perform the same search with this PR to see the parentheses added to the query. The results of the search should be the same with the PR, or should fix the issue mentioned above.

# Documentation Status

No documentation changes necessary

# Additional Notes:
N/A

# Interested parties
@aOelschlager 
@Islandora/committers
