### PR TITLE
Remove Facet block as dependency for Ajax driven Search views

### DIFF
--- a/advanced_search.libraries.yml
+++ b/advanced_search.libraries.yml
@@ -17,3 +17,8 @@ advanced.search.pager:
   css:
     component:
       css/advanced_search.pager.css: {}
+
+advanced.search.facets_views_ajax: 
+  js: 
+     js/facets/facets-views-ajax.js: {}
+

--- a/advanced_search.module
+++ b/advanced_search.module
@@ -45,9 +45,6 @@ function advanced_search_library_info_alter(&$libraries, $extension) {
     $libraries['soft-limit']['js'] = [
       "$path/soft-limit.js" => [],
     ];
-    $libraries['drupal.facets.views-ajax']['js'] = [
-      "$path/facets-views-ajax.js" => [],
-    ];
   }
 }
 
@@ -111,6 +108,7 @@ function advanced_search_preprocess_views_view(&$variables) {
     $format = \Drupal::request()->query->get('display') ?? $config->get(SettingsForm::DISPLAY_DEFAULT);
     $variables['attributes']['class'][] = "view-{$format}";
     $view->element['#attached']['library'][] = 'advanced_search/advanced.search.pager';
+    $view->element['#attached']['library'][] = 'advanced_search/advanced.search.facets_views_ajax';
   }
   $view = &$variables['view'];
 }

--- a/js/facets/facets-views-ajax.js
+++ b/js/facets/facets-views-ajax.js
@@ -136,13 +136,15 @@
         .replace(/-/g, "_");
       blocks[block_id] = "#" + id;
     });
-    Drupal.ajax({
-      url: Drupal.url("islandora-advanced-search-ajax-blocks"),
-      submit: {
-        link: url,
-        blocks: blocks,
-      },
-    }).execute();
+    if (Object.keys(blocks) > 0) {
+      Drupal.ajax({
+        url: Drupal.url("islandora-advanced-search-ajax-blocks"),
+        submit: {
+          link: url,
+          blocks: blocks,
+        },
+      }).execute();
+    }
   }
 
   // On location change reload all the blocks / ajax view.

--- a/js/facets/facets-views-ajax.js
+++ b/js/facets/facets-views-ajax.js
@@ -136,7 +136,7 @@
         .replace(/-/g, "_");
       blocks[block_id] = "#" + id;
     });
-    if (Object.keys(blocks) > 0) {
+    if (Object.keys(blocks).length > 0) {
       Drupal.ajax({
         url: Drupal.url("islandora-advanced-search-ajax-blocks"),
         submit: {


### PR DESCRIPTION
# What does this Pull Request do?

Provide a brief description of what the intended result of the PR will be and/or what
 problem it solves.

* **Related GitHub Issue**: https://github.com/Islandora/advanced_search/issues/69

* **Other Relevant Links**: (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Everything expected to work the same as before 
* Any case that Advanced Search view (page or block) without Facet block(s) placement has Ajax loaded working as expected. 


# How should this be tested?

A description of what steps someone could take to:
* Setup Search view with Advanced search setup (as place or blocks) has Ajax enabled.
* Make sure it has no Facets block placement
* Start using the features: 
    * searching form, 
    * click display modes 
    * change sorting option
* **Use Advanced search module code with 2.x or current releases:** the Advanced search view (with Ajax enabled) doesn't  reload with updated filtering, Advanced Search Form has no response, and other Ajax behaviours are not active. 
* **With this PR:** Expected the AJAX reloading as normal. 

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
