### PR TITLE
Configuration option to select specific fields for querying when "search all fields"

### DIFF
--- a/config/schema/advanced_search.schema.yml
+++ b/config/schema/advanced_search.schema.yml
@@ -34,3 +34,9 @@ advanced_search.settings:
     facet_truncate:
       type: string
       label: Truncate Facet
+    query_fields:
+      type: sequence
+      label: Query Fields
+      sequence:
+        type: string
+        label: Field identifier

--- a/src/AdvancedSearchQuery.php
+++ b/src/AdvancedSearchQuery.php
@@ -206,16 +206,17 @@ class AdvancedSearchQuery {
 
         if ($isSearchAllFields) {
           // Get configured query fields from settings.
-          $configured_query_fields = $config->get(SettingsForm::QUERY_FIELDS);
-
-          foreach ($field_mapping as $key => $field) {
-            foreach ($field as $f => $item) {
+          $configured_query_fields = $config->get(SettingsForm::QUERY_FIELDS) ?: [];
+          
+          // field_mapping structure: [field_id => [language => solr_field_name]]
+          foreach ($field_mapping as $field_id => $languages) {
+            foreach ($languages as $lang => $solr_field_name) {
               // bs_ are boolean fields, do not work well with text search.
-              if (substr($item, 0, 3) !== "bs_") {
+              if (substr($solr_field_name, 0, 3) !== "bs_") {
 
                 // If query_fields is configured, only include those fields.
-                if (empty($configured_query_fields) || in_array($f, $configured_query_fields)) {
-                  array_push($query_fields, $item);
+                if (empty($configured_query_fields) || in_array($field_id, $configured_query_fields)) {
+                  array_push($query_fields, $solr_field_name);
                 }
               }
             }
@@ -230,14 +231,16 @@ class AdvancedSearchQuery {
       }
 
       if ($backend->getConfiguration()['highlight_data']) {
-        // Just highlight string and text fields to avoid Solr exceptions.
-          $highlighted_fields = array_filter(array_unique($fields_list), function ($v) {
-          return preg_match('/^t.*?[sm]_/', $v) || preg_match('/^s[sm]_/', $v);
-        });
+        // // Just highlight string and text fields to avoid Solr exceptions.
+        // $highlighted_fields = array_filter(array_unique($fields_list), function ($v) {
+        //   return preg_match('/^t.*?[sm]_/', $v) || preg_match('/^s[sm]_/', $v);
+        // });
 
-        if (empty($highlighted_fields)) {
-          $highlighted_fields = ['*'];
-        }
+        // if (empty($highlighted_fields)) {
+        //   $highlighted_fields = ['*'];
+        // }
+        $highlighted_fields = [];
+
 
         $this->setHighlighting($solarium_query, $search_api_query, $highlighted_fields);
 

--- a/src/AdvancedSearchQuery.php
+++ b/src/AdvancedSearchQuery.php
@@ -17,7 +17,8 @@ use Drupal\search_api_solr\Utility\Utility as SearchAPISolrUtility;
 /**
  * Alter current search query / view from using URL parameters.
  */
-class AdvancedSearchQuery {
+class AdvancedSearchQuery
+{
 
   use GetConfigTrait;
 
@@ -47,7 +48,8 @@ class AdvancedSearchQuery {
    * @param string $recurse_parameter
    *   The field that signifies the search should be recursive.
    */
-  public function __construct(string $query_parameter = self::DEFAULT_QUERY_PARAM, string $recurse_parameter = self::DEFAULT_RECURSE_PARAM) {
+  public function __construct(string $query_parameter = self::DEFAULT_QUERY_PARAM, string $recurse_parameter = self::DEFAULT_RECURSE_PARAM)
+  {
     $this->queryParameter = $query_parameter;
     $this->recurseParameter = $recurse_parameter;
   }
@@ -58,7 +60,8 @@ class AdvancedSearchQuery {
    * @return string
    *   The query parameter to use that stores the search terms.
    */
-  public static function getQueryParameter() {
+  public static function getQueryParameter()
+  {
     return self::getConfig(SettingsForm::SEARCH_QUERY_PARAMETER, self::DEFAULT_QUERY_PARAM);
   }
 
@@ -69,7 +72,8 @@ class AdvancedSearchQuery {
    *   The recurse parameter used to indicate that the search should be
    *   recursive.
    */
-  public static function getRecurseParameter() {
+  public static function getRecurseParameter()
+  {
     return self::getConfig(SettingsForm::SEARCH_RECURSIVE_PARAMETER, self::DEFAULT_RECURSE_PARAM);
   }
 
@@ -82,7 +86,8 @@ class AdvancedSearchQuery {
    * @return \Drupal\advanced_search\AdvancedSearchQueryTerm[]
    *   A list of search terms.
    */
-  public function getTerms(Request $request) {
+  public function getTerms(Request $request)
+  {
     $terms = [];
     if ($request->query->has($this->queryParameter)) {
       $query_params = $request->query->all()[$this->queryParameter];
@@ -104,7 +109,8 @@ class AdvancedSearchQuery {
    * @return bool
    *   TRUE if the search should recurse FALSE otherwise.
    */
-  public function shouldRecurse(Request $request) {
+  public function shouldRecurse(Request $request)
+  {
     if ($request->query->has($this->recurseParameter)) {
       $recurse_param = $request->query->get($this->recurseParameter);
       return filter_var($recurse_param, FILTER_VALIDATE_BOOLEAN);
@@ -121,7 +127,8 @@ class AdvancedSearchQuery {
    * @return bool
    *   TRUE if all terms are to be excluded otherwise FALSE.
    */
-  protected function negativeQuery(array $terms) {
+  protected function negativeQuery(array $terms)
+  {
     foreach ($terms as $term) {
       if ($term->getInclude()) {
         return FALSE;
@@ -140,7 +147,8 @@ class AdvancedSearchQuery {
    * @param \Drupal\search_api\Query\QueryInterface $search_api_query
    *   The search api query from which the solr query was build.
    */
-  public function alterQuery(Request $request, SolariumQueryInterface &$solarium_query, DrupalQueryInterface $search_api_query) {
+  public function alterQuery(Request $request, SolariumQueryInterface &$solarium_query, DrupalQueryInterface $search_api_query)
+  {
     // Only apply if a Advanced Search Query was made.
     $terms = $this->getTerms($request);
     if (!empty($terms)) {
@@ -152,7 +160,7 @@ class AdvancedSearchQuery {
 
       // Disable for Lucene and wildcard
       //$q[] = "{!boost b=boost_document}";
-      
+
       // Create a flag for active/inactive dismax.
       $config = \Drupal::config(SettingsForm::CONFIG_NAME);
       $isDismax = $config->get(SettingsForm::EDISMAX_SEARCH_FLAG);
@@ -176,7 +184,6 @@ class AdvancedSearchQuery {
       // Set edismax is enabled if the field set to "all".
       if ($term->getField() === "all") {
         $isSearchAllFields = TRUE;
-
       }
 
       // For multiple conditions.
@@ -190,9 +197,7 @@ class AdvancedSearchQuery {
         // Set dismax is enabled if the field set to "all".
         if ($term->getField() === "all") {
           $isSearchAllFields = TRUE;
-
         }
-
       }
       $q = implode(' ', $q);
 
@@ -207,7 +212,7 @@ class AdvancedSearchQuery {
         if ($isSearchAllFields) {
           // Get configured query fields from settings.
           $configured_query_fields = $config->get(SettingsForm::QUERY_FIELDS) ?: [];
-          
+
           // field_mapping structure: [field_id => [language => solr_field_name]]
           foreach ($field_mapping as $field_id => $languages) {
             foreach ($languages as $lang => $solr_field_name) {
@@ -221,27 +226,29 @@ class AdvancedSearchQuery {
               }
             }
           }
-        }
-        else {
+        } else {
           $query_fields = $fields_list;
-
         }
         $query_fields = implode(" ", array_unique($query_fields));
         $dismax->setQueryFields($query_fields);
       }
 
-      // Use all fields for highlighting if all fields are searched.
-      $highlight_source_fields = $isSearchAllFields && isset($query_fields) ? explode(" ", $query_fields) : $fields_list;
+      // if all fields are searched, use the query_fields for highlighting.
+      if ($isSearchAllFields && isset($query_fields)) {
+        // Convert back to an array.
+        $highlight_source_fields = explode(" ", $query_fields);
+      } else {
+        $highlight_source_fields = $fields_list;
+      }
 
       if ($backend->getConfiguration()['highlight_data']) {
         // Just highlight string and text fields to avoid Solr exceptions.
-        // Exclude fulltext fields (containing 'fulltext') as they don't have offsets indexed.
+        // Exclude tm_X3b_*_fulltext_title
         $highlighted_fields = array_filter(array_unique($highlight_source_fields), function ($v) {
-          return !empty($v) && (preg_match('/^t.*?[sm]_/', $v) || preg_match('/^s[sm]_/', $v)) && strpos($v, 'fulltext') === FALSE;
+          return !empty($v) && (preg_match('/^t.*?[sm]_/', $v) || preg_match('/^s[sm]_/', $v)) && !preg_match('/^tm_X3b_.*_fulltext_title$/', $v);
         });
 
-        // Only set highlighting if we have valid fields.
-        // Don't use wildcard as it causes Solr to try highlighting fields without offsets.
+        // Check if there are any valid fields for highlighting.
         if (!empty($highlighted_fields)) {
           $this->setHighlighting($solarium_query, $search_api_query, $highlighted_fields);
         }
@@ -268,7 +275,8 @@ class AdvancedSearchQuery {
    * @param string $display_id
    *   The view display to potentially alter.
    */
-  public function alterView(Request $request, ViewExecutable $view, $display_id) {
+  public function alterView(Request $request, ViewExecutable $view, $display_id)
+  {
     $views = Utilities::getAdvancedSearchViewDisplays();
     // Only specify contextual filters for views which the advanced search
     // blocks are derived from.
@@ -287,8 +295,7 @@ class AdvancedSearchQuery {
           // Change the argument to the exception value which should cause the
           // contextual filter to be ignored.
           $view->args[$index] = $display_arguments[$immediate_children_contextual_filter]['exception']['value'];
-        }
-        else {
+        } else {
           // Explicitly set the default argument for AJAX requests.
           // We need to restore the default as that functionality is currently
           // broken. @see https://www.drupal.org/project/drupal/issues/3173778
@@ -322,7 +329,8 @@ class AdvancedSearchQuery {
    * @return \Drupal\Core\Url
    *   Url for the given request combined with search query parameters.
    */
-  public function toUrl(Request $request, array $terms, bool $recurse, $route = NULL) {
+  public function toUrl(Request $request, array $terms, bool $recurse, $route = NULL)
+  {
     $query_params = $request->query->all();
     if ($route) {
       $url = Url::fromRoute($route);
@@ -330,8 +338,7 @@ class AdvancedSearchQuery {
       // new page, so it should be disabled.
       unset($query_params[FormBuilderInterface::AJAX_FORM_REQUEST]);
       unset($query_params[MainContentViewSubscriber::WRAPPER_FORMAT]);
-    }
-    else {
+    } else {
       $url = Url::createFromRequest($request);
     }
     unset($query_params[$this->queryParameter]);
@@ -340,8 +347,7 @@ class AdvancedSearchQuery {
     }
     if ($recurse) {
       $query_params[$this->recurseParameter] = '1';
-    }
-    else {
+    } else {
       unset($query_params[$this->recurseParameter]);
     }
     $url->setOptions(['query' => $query_params]);
@@ -358,7 +364,8 @@ class AdvancedSearchQuery {
    * @param array $highlighted_fields
    *   (optional) The solr fields to be highlighted.
    */
-  protected function setHighlighting(SolariumQueryInterface $solarium_query, DrupalQueryInterface $search_api_query, array $highlighted_fields = []) {
+  protected function setHighlighting(SolariumQueryInterface $solarium_query, DrupalQueryInterface $search_api_query, array $highlighted_fields = [])
+  {
     $index = $search_api_query->getIndex();
     $settings = SearchAPISolrUtility::getIndexSolrSettings($index);
     $highlighter = $settings['highlighter'];
@@ -404,5 +411,4 @@ class AdvancedSearchQuery {
       $hl->addField($highlighted_field);
     }
   }
-
 }

--- a/src/AdvancedSearchQuery.php
+++ b/src/AdvancedSearchQuery.php
@@ -17,8 +17,7 @@ use Drupal\search_api_solr\Utility\Utility as SearchAPISolrUtility;
 /**
  * Alter current search query / view from using URL parameters.
  */
-class AdvancedSearchQuery
-{
+class AdvancedSearchQuery {
 
   use GetConfigTrait;
 
@@ -48,8 +47,7 @@ class AdvancedSearchQuery
    * @param string $recurse_parameter
    *   The field that signifies the search should be recursive.
    */
-  public function __construct(string $query_parameter = self::DEFAULT_QUERY_PARAM, string $recurse_parameter = self::DEFAULT_RECURSE_PARAM)
-  {
+  public function __construct(string $query_parameter = self::DEFAULT_QUERY_PARAM, string $recurse_parameter = self::DEFAULT_RECURSE_PARAM) {
     $this->queryParameter = $query_parameter;
     $this->recurseParameter = $recurse_parameter;
   }
@@ -60,8 +58,7 @@ class AdvancedSearchQuery
    * @return string
    *   The query parameter to use that stores the search terms.
    */
-  public static function getQueryParameter()
-  {
+  public static function getQueryParameter() {
     return self::getConfig(SettingsForm::SEARCH_QUERY_PARAMETER, self::DEFAULT_QUERY_PARAM);
   }
 
@@ -72,8 +69,7 @@ class AdvancedSearchQuery
    *   The recurse parameter used to indicate that the search should be
    *   recursive.
    */
-  public static function getRecurseParameter()
-  {
+  public static function getRecurseParameter() {
     return self::getConfig(SettingsForm::SEARCH_RECURSIVE_PARAMETER, self::DEFAULT_RECURSE_PARAM);
   }
 
@@ -86,8 +82,7 @@ class AdvancedSearchQuery
    * @return \Drupal\advanced_search\AdvancedSearchQueryTerm[]
    *   A list of search terms.
    */
-  public function getTerms(Request $request)
-  {
+  public function getTerms(Request $request) {
     $terms = [];
     if ($request->query->has($this->queryParameter)) {
       $query_params = $request->query->all()[$this->queryParameter];
@@ -109,8 +104,7 @@ class AdvancedSearchQuery
    * @return bool
    *   TRUE if the search should recurse FALSE otherwise.
    */
-  public function shouldRecurse(Request $request)
-  {
+  public function shouldRecurse(Request $request) {
     if ($request->query->has($this->recurseParameter)) {
       $recurse_param = $request->query->get($this->recurseParameter);
       return filter_var($recurse_param, FILTER_VALIDATE_BOOLEAN);
@@ -127,8 +121,7 @@ class AdvancedSearchQuery
    * @return bool
    *   TRUE if all terms are to be excluded otherwise FALSE.
    */
-  protected function negativeQuery(array $terms)
-  {
+  protected function negativeQuery(array $terms) {
     foreach ($terms as $term) {
       if ($term->getInclude()) {
         return FALSE;
@@ -147,8 +140,7 @@ class AdvancedSearchQuery
    * @param \Drupal\search_api\Query\QueryInterface $search_api_query
    *   The search api query from which the solr query was build.
    */
-  public function alterQuery(Request $request, SolariumQueryInterface &$solarium_query, DrupalQueryInterface $search_api_query)
-  {
+  public function alterQuery(Request $request, SolariumQueryInterface &$solarium_query, DrupalQueryInterface $search_api_query) {
     // Only apply if a Advanced Search Query was made.
     $terms = $this->getTerms($request);
     if (!empty($terms)) {
@@ -160,7 +152,7 @@ class AdvancedSearchQuery
 
       // Disable for Lucene and wildcard
       //$q[] = "{!boost b=boost_document}";
-
+      
       // Create a flag for active/inactive dismax.
       $config = \Drupal::config(SettingsForm::CONFIG_NAME);
       $isDismax = $config->get(SettingsForm::EDISMAX_SEARCH_FLAG);
@@ -184,6 +176,7 @@ class AdvancedSearchQuery
       // Set edismax is enabled if the field set to "all".
       if ($term->getField() === "all") {
         $isSearchAllFields = TRUE;
+
       }
 
       // For multiple conditions.
@@ -197,7 +190,9 @@ class AdvancedSearchQuery
         // Set dismax is enabled if the field set to "all".
         if ($term->getField() === "all") {
           $isSearchAllFields = TRUE;
+
         }
+
       }
       $q = implode(' ', $q);
 
@@ -212,7 +207,7 @@ class AdvancedSearchQuery
         if ($isSearchAllFields) {
           // Get configured query fields from settings.
           $configured_query_fields = $config->get(SettingsForm::QUERY_FIELDS) ?: [];
-
+          
           // field_mapping structure: [field_id => [language => solr_field_name]]
           foreach ($field_mapping as $field_id => $languages) {
             foreach ($languages as $lang => $solr_field_name) {
@@ -226,8 +221,10 @@ class AdvancedSearchQuery
               }
             }
           }
-        } else {
+        }
+        else {
           $query_fields = $fields_list;
+
         }
         $query_fields = implode(" ", array_unique($query_fields));
         $dismax->setQueryFields($query_fields);
@@ -237,7 +234,8 @@ class AdvancedSearchQuery
       if ($isSearchAllFields && isset($query_fields)) {
         // Convert back to an array.
         $highlight_source_fields = explode(" ", $query_fields);
-      } else {
+      }
+      else {
         $highlight_source_fields = $fields_list;
       }
 
@@ -275,8 +273,7 @@ class AdvancedSearchQuery
    * @param string $display_id
    *   The view display to potentially alter.
    */
-  public function alterView(Request $request, ViewExecutable $view, $display_id)
-  {
+  public function alterView(Request $request, ViewExecutable $view, $display_id) {
     $views = Utilities::getAdvancedSearchViewDisplays();
     // Only specify contextual filters for views which the advanced search
     // blocks are derived from.
@@ -295,7 +292,8 @@ class AdvancedSearchQuery
           // Change the argument to the exception value which should cause the
           // contextual filter to be ignored.
           $view->args[$index] = $display_arguments[$immediate_children_contextual_filter]['exception']['value'];
-        } else {
+        }
+        else {
           // Explicitly set the default argument for AJAX requests.
           // We need to restore the default as that functionality is currently
           // broken. @see https://www.drupal.org/project/drupal/issues/3173778
@@ -329,8 +327,7 @@ class AdvancedSearchQuery
    * @return \Drupal\Core\Url
    *   Url for the given request combined with search query parameters.
    */
-  public function toUrl(Request $request, array $terms, bool $recurse, $route = NULL)
-  {
+  public function toUrl(Request $request, array $terms, bool $recurse, $route = NULL) {
     $query_params = $request->query->all();
     if ($route) {
       $url = Url::fromRoute($route);
@@ -338,7 +335,8 @@ class AdvancedSearchQuery
       // new page, so it should be disabled.
       unset($query_params[FormBuilderInterface::AJAX_FORM_REQUEST]);
       unset($query_params[MainContentViewSubscriber::WRAPPER_FORMAT]);
-    } else {
+    }
+    else {
       $url = Url::createFromRequest($request);
     }
     unset($query_params[$this->queryParameter]);
@@ -347,7 +345,8 @@ class AdvancedSearchQuery
     }
     if ($recurse) {
       $query_params[$this->recurseParameter] = '1';
-    } else {
+    }
+    else {
       unset($query_params[$this->recurseParameter]);
     }
     $url->setOptions(['query' => $query_params]);
@@ -364,8 +363,7 @@ class AdvancedSearchQuery
    * @param array $highlighted_fields
    *   (optional) The solr fields to be highlighted.
    */
-  protected function setHighlighting(SolariumQueryInterface $solarium_query, DrupalQueryInterface $search_api_query, array $highlighted_fields = [])
-  {
+  protected function setHighlighting(SolariumQueryInterface $solarium_query, DrupalQueryInterface $search_api_query, array $highlighted_fields = []) {
     $index = $search_api_query->getIndex();
     $settings = SearchAPISolrUtility::getIndexSolrSettings($index);
     $highlighter = $settings['highlighter'];
@@ -411,4 +409,5 @@ class AdvancedSearchQuery
       $hl->addField($highlighted_field);
     }
   }
+
 }

--- a/src/AdvancedSearchQuery.php
+++ b/src/AdvancedSearchQuery.php
@@ -230,18 +230,21 @@ class AdvancedSearchQuery {
         $dismax->setQueryFields($query_fields);
       }
 
+      // Use all fields for highlighting if all fields are searched.
+      $highlight_source_fields = $isSearchAllFields && isset($query_fields) ? explode(" ", $query_fields) : $fields_list;
+
       if ($backend->getConfiguration()['highlight_data']) {
         // Just highlight string and text fields to avoid Solr exceptions.
-        $highlighted_fields = array_filter(array_unique($fields_list), function ($v) {
-          return preg_match('/^t.*?[sm]_/', $v) || preg_match('/^s[sm]_/', $v);
+        // Exclude fulltext fields (containing 'fulltext') as they don't have offsets indexed.
+        $highlighted_fields = array_filter(array_unique($highlight_source_fields), function ($v) {
+          return !empty($v) && (preg_match('/^t.*?[sm]_/', $v) || preg_match('/^s[sm]_/', $v)) && strpos($v, 'fulltext') === FALSE;
         });
 
-        if (empty($highlighted_fields)) {
-          $highlighted_fields = ['*'];
+        // Only set highlighting if we have valid fields.
+        // Don't use wildcard as it causes Solr to try highlighting fields without offsets.
+        if (!empty($highlighted_fields)) {
+          $this->setHighlighting($solarium_query, $search_api_query, $highlighted_fields);
         }
-
-
-        $this->setHighlighting($solarium_query, $search_api_query, $highlighted_fields);
 
         // The Search API Highlight processor checks if the 'keys' field of
         // the Search API Query is non-empty before creating an excerpt.

--- a/src/AdvancedSearchQuery.php
+++ b/src/AdvancedSearchQuery.php
@@ -205,11 +205,18 @@ class AdvancedSearchQuery {
         $query_fields = [];
 
         if ($isSearchAllFields) {
+          // Get configured query fields from settings.
+          $configured_query_fields = $config->get(SettingsForm::QUERY_FIELDS);
+
           foreach ($field_mapping as $key => $field) {
             foreach ($field as $f => $item) {
               // bs_ are boolean fields, do not work well with text search.
               if (substr($item, 0, 3) !== "bs_") {
-                array_push($query_fields, $item);
+
+                // If query_fields is configured, only include those fields.
+                if (empty($configured_query_fields) || in_array($f, $configured_query_fields)) {
+                  array_push($query_fields, $item);
+                }
               }
             }
           }

--- a/src/AdvancedSearchQuery.php
+++ b/src/AdvancedSearchQuery.php
@@ -231,15 +231,14 @@ class AdvancedSearchQuery {
       }
 
       if ($backend->getConfiguration()['highlight_data']) {
-        // // Just highlight string and text fields to avoid Solr exceptions.
-        // $highlighted_fields = array_filter(array_unique($fields_list), function ($v) {
-        //   return preg_match('/^t.*?[sm]_/', $v) || preg_match('/^s[sm]_/', $v);
-        // });
+        // Just highlight string and text fields to avoid Solr exceptions.
+        $highlighted_fields = array_filter(array_unique($fields_list), function ($v) {
+          return preg_match('/^t.*?[sm]_/', $v) || preg_match('/^s[sm]_/', $v);
+        });
 
-        // if (empty($highlighted_fields)) {
-        //   $highlighted_fields = ['*'];
-        // }
-        $highlighted_fields = [];
+        if (empty($highlighted_fields)) {
+          $highlighted_fields = ['*'];
+        }
 
 
         $this->setHighlighting($solarium_query, $search_api_query, $highlighted_fields);

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -12,7 +12,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Config form for Islandora Advanced Search settings.
  */
-class SettingsForm extends ConfigFormBase {
+class SettingsForm extends ConfigFormBase
+{
 
   use GetConfigTrait;
 
@@ -28,6 +29,7 @@ class SettingsForm extends ConfigFormBase {
   const DISPLAY_LIST_FLAG = 'list_on_off';
   const DISPLAY_GRID_FLAG = 'grid_on_off';
   const DISPLAY_DEFAULT = 'default-display-mode';
+  const QUERY_FIELDS = 'query_fields';
 
   /**
    * Constructs a \Drupal\system\ConfigFormBase object.
@@ -35,37 +37,66 @@ class SettingsForm extends ConfigFormBase {
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
    */
-  final public function __construct(ConfigFactoryInterface $config_factory) {
+  final public function __construct(ConfigFactoryInterface $config_factory)
+  {
     $this->setConfigFactory($config_factory);
   }
 
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container)
+  {
     return new static($container->get('config.factory'));
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
+  public function getFormId()
+  {
     return 'advanced_search_settings_form';
   }
 
   /**
    * {@inheritdoc}
    */
-  protected function getEditableConfigNames() {
+  protected function getEditableConfigNames()
+  {
     return [
       self::CONFIG_NAME,
     ];
   }
 
   /**
+   * Get available fields from all Search API indexes.
+   *
+   * @return array
+   *   An associative array of field identifiers to field labels.
+   */
+  protected function getAvailableFields()
+  {
+    $field_options = [];
+
+    // Load all Search API indexes.
+    $index_storage = \Drupal::entityTypeManager()->getStorage('search_api_index');
+    $indexes = $index_storage->loadMultiple();
+
+    foreach ($indexes as $index) {
+      $fields = $index->getFields();
+      foreach ($fields as $field_id => $field) {
+        $field_options[$field_id] = $field->getLabel();
+      }
+    }
+
+    return $field_options;
+  }
+
+  /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state)
+  {
     $form['eDisMax'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Advanced Search Block'),
@@ -114,6 +145,25 @@ class SettingsForm extends ConfigFormBase {
       '#title' => $this->t('If enabled, set the label for the option of searching all fields'),
       '#description' => $this->t('E.g. keyword.'),
       '#default_value' => self::getConfig(self::EDISMAX_SEARCH_LABEL, "Keyword"),
+    ];
+
+    // Get all available Solr fields from all Search API indexes.
+    $field_options = $this->getAvailableFields();
+
+    // Create scrollable container for checkboxes.
+    $form['eDisMax']['textfields_container']['query_fields_wrapper'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'style' => 'max-height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 10px; background: #f9f9f9;',
+      ],
+    ];
+
+    $form['eDisMax']['textfields_container']['query_fields_wrapper'][self::QUERY_FIELDS] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Query fields'),
+      '#description' => $this->t('Select which fields should be queried when searching all fields label (keyword) chosen. If no fields are selected, all fields will be searched.'),
+      '#options' => $field_options,
+      '#default_value' => self::getConfig(self::QUERY_FIELDS, []),
     ];
 
     $form['display-mode'] = [
@@ -197,7 +247,8 @@ class SettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state)
+  {
     $config = $this->configFactory->getEditable(self::CONFIG_NAME);
     $config
       ->set(self::SEARCH_QUERY_PARAMETER, $form_state->getValue(self::SEARCH_QUERY_PARAMETER))
@@ -211,8 +262,8 @@ class SettingsForm extends ConfigFormBase {
       ->set(self::DISPLAY_LIST_FLAG, $form_state->getValue(self::DISPLAY_LIST_FLAG))
       ->set(self::DISPLAY_GRID_FLAG, $form_state->getValue(self::DISPLAY_GRID_FLAG))
       ->set(self::DISPLAY_DEFAULT, $form_state->getValue(self::DISPLAY_DEFAULT))
+      ->set(self::QUERY_FIELDS, $form_state->getValue(self::QUERY_FIELDS))
       ->save();
     parent::submitForm($form, $form_state);
   }
-
 }

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -103,7 +103,7 @@ class SettingsForm extends ConfigFormBase
       '#weight' => -1,
     ];
     $form['eDisMax']['advanced-search-block-description'] = [
-      '#markup' => $this->t("Advanced Search Blocks are available in the Blocks interface for each Search API view. When placing an Advanced Search Block, you can configure the fields that are used for field-based search and whether a “recursive” search is available.  The following settings apply to all Advanced Search blocks."),
+      '#markup' => $this->t('Advanced Search Blocks are available in the Blocks interface for each Search API view. When placing an Advanced Search Block, you can configure the fields that are used for field-based search and whether a "recursive" search is available.  The following settings apply to all Advanced Search blocks.'),
       '#weight' => -2,
     ];
 
@@ -136,7 +136,7 @@ class SettingsForm extends ConfigFormBase
         ->t('Enable searching all fields'),
       '#description' => $this->t('<ul>
           <li>This makes an additional option visible in all Advanced Search Blocks, which searches across all fields. Its label is configured below.</li>
-          <li>This setting must be enabled for the “Simple Search Block” to function.</li>
+          <li>This setting must be enabled for the "Simple Search Block" to function.</li>
         </ul>'),
       '#default_value' => self::getConfig(self::SEARCH_ALL_FIELDS_FLAG, 0),
     ];
@@ -147,21 +147,35 @@ class SettingsForm extends ConfigFormBase
       '#default_value' => self::getConfig(self::EDISMAX_SEARCH_LABEL, "Keyword"),
     ];
 
-    // Get all available Solr fields from all Search API indexes.
+    // Query Fields Block 
+    $form['query_fields_block'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Query Fields'),
+      '#weight' => -0.5,
+    ];
+
     $field_options = $this->getAvailableFields();
 
-    // Create scrollable container for checkboxes.
-    $form['eDisMax']['textfields_container']['query_fields_wrapper'] = [
+    $base_url = \Drupal::request()->getSchemeAndHttpHost();
+    $query_fields_description = $this->t('Select which fields should be queried when searching all fields label (keyword) chosen. If no fields are selected, <a href="@fields_url" target="_blank">all fields will be searched</a>.', [
+      '@fields_url' => $base_url . '/admin/config/search/search-api/index/default_solr_index_islandora_lite/fields',
+    ]);
+
+    $form['query_fields_block']['query_fields_description'] = [
+      '#type' => 'item',
+      '#markup' => '<div style=" background: #f0f0f0; border-left: 4px solid #0074bd;">' . $query_fields_description . '</div>',
+    ];
+
+    $form['query_fields_block']['query_fields_wrapper'] = [
       '#type' => 'container',
       '#attributes' => [
-        'style' => 'max-height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 10px; background: #f9f9f9;',
+        'style' => 'max-height: 350px; overflow-y: auto; border: 1px solid #ccc; padding: 10px; background: #f9f9f9;',
       ],
     ];
 
-    $form['eDisMax']['textfields_container']['query_fields_wrapper'][self::QUERY_FIELDS] = [
+    $form['query_fields_block']['query_fields_wrapper'][self::QUERY_FIELDS] = [
       '#type' => 'checkboxes',
-      '#title' => $this->t('Query fields'),
-      '#description' => $this->t('Select which fields should be queried when searching all fields label (keyword) chosen. If no fields are selected, all fields will be searched.'),
+      '#title' => $this->t('Select fields to query'),
       '#options' => $field_options,
       '#default_value' => self::getConfig(self::QUERY_FIELDS, []),
     ];

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -79,7 +79,7 @@ class SettingsForm extends ConfigFormBase
     $field_options = [];
 
     // Load all Search API indexes.
-    $index_storage = \Drupal::entityTypeManager()->getStorage('search_api_index');
+    $field_options[$field_id] = $field->getLabel() . " (" . $field_id . ")";
     $indexes = $index_storage->loadMultiple();
 
     foreach ($indexes as $index) {
@@ -247,8 +247,11 @@ class SettingsForm extends ConfigFormBase
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state)
-  {
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Filter out unchecked checkboxes (value = '0') from query_fields.
+    $query_fields = $form_state->getValue(self::QUERY_FIELDS);
+    $query_fields = is_array($query_fields) ? array_filter($query_fields) : [];
+
     $config = $this->configFactory->getEditable(self::CONFIG_NAME);
     $config
       ->set(self::SEARCH_QUERY_PARAMETER, $form_state->getValue(self::SEARCH_QUERY_PARAMETER))
@@ -262,7 +265,7 @@ class SettingsForm extends ConfigFormBase
       ->set(self::DISPLAY_LIST_FLAG, $form_state->getValue(self::DISPLAY_LIST_FLAG))
       ->set(self::DISPLAY_GRID_FLAG, $form_state->getValue(self::DISPLAY_GRID_FLAG))
       ->set(self::DISPLAY_DEFAULT, $form_state->getValue(self::DISPLAY_DEFAULT))
-      ->set(self::QUERY_FIELDS, $form_state->getValue(self::QUERY_FIELDS))
+      ->set(self::QUERY_FIELDS, $query_fields)
       ->save();
     parent::submitForm($form, $form_state);
   }

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -79,13 +79,13 @@ class SettingsForm extends ConfigFormBase
     $field_options = [];
 
     // Load all Search API indexes.
-    $field_options[$field_id] = $field->getLabel() . " (" . $field_id . ")";
+    $index_storage = \Drupal::entityTypeManager()->getStorage('search_api_index');
     $indexes = $index_storage->loadMultiple();
 
     foreach ($indexes as $index) {
       $fields = $index->getFields();
       foreach ($fields as $field_id => $field) {
-        $field_options[$field_id] = $field->getLabel();
+        $field_options[$field_id] = $field->getLabel() . " (" . $field_id . ")";
       }
     }
 


### PR DESCRIPTION
# What does this Pull Request do?

Provide a brief description of what the intended result of the PR will be and/or what
 problem it solves.

* **Related GitHub Issue**: https://github.com/Islandora/advanced_search/issues/76


# What's new?
Added form with checkboxes to choose which fields to query from when using "searching all fields".  
e.g. A collection with genre "test" will not show up when querying "test" if genre checkbox not chosen.

Default behaviour where no checkboxes are chosen, all fields are queried. 


# How should this be tested?
1. Create a dummy collection
2. Go to /admin/config/search/advanced and choose which fields to query from
3. Search the collection with the advanced search bar and "searching all fields" label (keyword)

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
