### PR TITLE
added configuration option for collection search recursion

### DIFF
--- a/config/schema/advanced_search.schema.yml
+++ b/config/schema/advanced_search.schema.yml
@@ -34,6 +34,9 @@ advanced_search.settings:
     facet_truncate:
       type: string
       label: Truncate Facet
+    recursive:
+      type: integer
+      label: Include Sub-Collections
     query_fields:
       type: sequence
       label: Query Fields

--- a/js/facets/facets-views-ajax.js
+++ b/js/facets/facets-views-ajax.js
@@ -4,20 +4,46 @@
  * Overrides the facets-view-ajax.js behavior from the 'facets' module.
  */
 (function ($, Drupal) {
-  "use strict";
+    "use strict";
 
-  // Generate events on push state.
-  (function (history) {
-    var pushState = history.pushState;
-    history.pushState = function (state, title, url) {
-      var ret = pushState.apply(this, arguments);
-      var event = new Event("pushstate");
-      window.dispatchEvent(event);
-      return ret;
-    };
-  })(window.history);
+    // For each search view override display mode config (in SearchPagerResultBlock.php)
+    jQuery( document ).ready(function() {
+        handleDisplayMode();
+    });
 
-  function parseQueryString( queryString ) {
+    jQuery(document).ajaxComplete(function() {
+        handleDisplayMode();
+    });
+
+    // Generate events on push state.
+    (function (history) {
+        var pushState = history.pushState;
+        history.pushState = function (state, title, url) {
+            var ret = pushState.apply(this, arguments);
+            var event = new Event("pushstate");
+            window.dispatchEvent(event);
+            return ret;
+        };
+    })(window.history);
+
+    function handleDisplayMode() {
+        var initial_display = jQuery('a.pager__link.pager__link--is-active.pager__display').attr('type');
+        if (initial_display == undefined) {
+            initial_display = jQuery("#override-default-display-mode").html();
+        }
+        if (jQuery('div.view.view-list').length == 1 && initial_display != "list") {
+            var search_view = jQuery('div.view.view-list');
+            search_view.removeClass("view-list");
+            search_view.addClass("view-grid");
+        }
+        if (jQuery('div.view.view-grid').length == 1 && initial_display != "grid") {
+            var search_view = jQuery('div.view.view-grid');
+            search_view.removeClass("view-grid");
+            search_view.addClass("view-list");
+        }
+    }
+
+    function parseQueryString( queryString ) {
         var params = {}, queries, temp, i, l;
 
         // Split into key/value pairs
@@ -32,237 +58,237 @@
         return params;
     };
 
-  function reload(url) {
-    // Update View.
-    if (drupalSettings && drupalSettings.views && drupalSettings.views.ajaxViews) {
-      var view_path = drupalSettings.views.ajax_path;
-      $.each(drupalSettings.views.ajaxViews, function (views_dom_id) {
-        var views_parameters = Drupal.Views.parseQueryString(url);
-        var views_arguments = Drupal.Views.parseViewArgs(url, "search");
-        var views_settings = $.extend(
-          {},
-          Drupal.views.instances[views_dom_id].settings,
-          views_arguments,
-          views_parameters
-        );
-        var views_ajax_settings =
-          Drupal.views.instances[views_dom_id].element_settings;
-        views_ajax_settings.submit = views_settings;
-        views_ajax_settings.url =
-          view_path + "?" + $.param(Drupal.Views.parseQueryString(url));
-        Drupal.ajax(views_ajax_settings).execute();
-      });
-    }
-
-    // Update items_per_page links in pager 
-    if (url.indexOf("items_per_page=") == -1) { 
-      // append items_per_page
-      $("a.pager__itemsperpage").each(function( index ) {
-        var newUrl = url + "&items_per_page=" + $(this).html();
-        $(this).attr("href", newUrl);
-      });
-    } 
-    else { 
-      // replace existed items_per_page
-      var params = parseQueryString(url.split("?")[1]);
-      var newParams = [];
-      var existingDateQuery = false; // true if a date query already exists
-
-      var links = {};
-      // update publication date in url if previously queried
-      for (var key in params) {
-        if (!params[key]) { // no search parameters in url
-          break;
-        }
-
-        // check for items_per_page query
-        if (!key.startsWith("items_per_page")) { 
-          newParams.push(key + "=" + params[key]);
-        }
-      }
-      var newParamsUrl = newParams.join('&');
-      $("a.pager__itemsperpage").each(function( index ) {
-        $(this).attr("href", url.split("?")[0] + '?' + newParamsUrl + "&items_per_page=" + $(this).html());
-      });
-    }
-
-
-
-    // Update display mode links in pager 
-    if (url.indexOf("display=") == -1) { 
-      // append items_per_page
-      $("a.pager__display").each(function( index ) {
-        var newUrl = url + "&display=" + $(this).attr('type');
-        $(this).attr("href", newUrl);
-      });
-      
-    } 
-    else { 
-      // replace existed display
-      var params = parseQueryString(url.split("?")[1]);
-      var newParams = [];
-      var existingDateQuery = false; // true if a date query already exists
-
-      var links = {};
-      // update publication date in url if previously queried
-      for (var key in params) {
-        if (!params[key]) { // no search parameters in url
-          break;
-        }
-
-        // check for display query
-        if (!key.startsWith("display")) { 
-          newParams.push(key + "=" + params[key]);
-        }
-      }
-      var newParamsUrl = newParams.join('&');
-      $("a.pager__display").each(function( index ) {
-
-        var value = $(this).attr('type');
-        $(this).attr("href", url.split("?")[0] + '?' + newParamsUrl + "&display=" + value);
-      });
-    }
-
-
-    
-    // Replace filter, pager, summary, and facet blocks.
-    var blocks = {};
-    $(
-      "[class*='block-plugin-id--islandora-advanced-search-result-pager'], [class*='block-plugin-id--views-exposed-filter-block'], [class*='block-facets']"
-    ).each(function () {
-      var id = $(this).attr("id");
-      var block_id = id
-        .slice("block-".length, id.length)
-        .replace(/--.*$/g, "")
-        .replace(/-/g, "_");
-      blocks[block_id] = "#" + id;
-    });
-    if (Object.keys(blocks).length > 0) {
-      Drupal.ajax({
-        url: Drupal.url("islandora-advanced-search-ajax-blocks"),
-        submit: {
-          link: url,
-          blocks: blocks,
-        },
-      }).execute();
-    }
-  }
-
-  // On location change reload all the blocks / ajax view.
-  window.addEventListener("pushstate", function (e) {
-    reload(window.location.href);
-  });
-
-  window.addEventListener("popstate", function (e) {
-    if (e.state != null) {
-      reload(window.location.href);
-    }
-  });
-
-  /**
-   * Push state on form/pager/facet change.
-   */
-  Drupal.behaviors.islandoraAdvancedSearchViewsAjax = {
-    attach: function (context, settings) {
-      window.historyInitiated = true;
-      // Remove existing behavior from form.
-      if (settings && settings.views && settings.views.ajaxViews) {
-        $.each(settings.views.ajaxViews, function (index, settings) {
-          var exposed_form = $(
-            "form#views-exposed-form-" +
-            settings.view_name.replace(/_/g, "-") +
-            "-" +
-            settings.view_display_id.replace(/_/g, "-")
-          );
-          $(once('exposed-form',
-            "form#views-exposed-form-" +
-            settings.view_name.replace(/_/g, "-") +
-            "-" +
-            settings.view_display_id.replace(/_/g, "-")))
-            .find("input[type=submit], input[type=image]")
-            .not("[data-drupal-selector=edit-reset]")
-            .each(function (index) {
-              $(this).unbind("click");
-              $(this).click(function (e) {
-                // Let ctrl/cmd click open in a new window.
-                if (e.shiftKey || e.ctrlKey || e.metaKey) {
-                  return;
-                }
-                e.preventDefault();
-                e.stopPropagation();
-                var href = window.location.href;
-                var params = Drupal.Views.parseQueryString(href);
-                // Remove the page if set as submitting the form should always take
-                // the user to the first page (facets do the same).
-                delete params.page;
-                // Include values from the form in the URL.
-                $.each(exposed_form.serializeArray(), function () {
-                  params[this.name] = this.value;
-                });
-                href = href.split("?")[0] + "?" + $.param(params);
-                window.history.pushState(null, document.title, href);
-              });
+    function reload(url) {
+        // Update View.
+        if (drupalSettings && drupalSettings.views && drupalSettings.views.ajaxViews) {
+            var view_path = drupalSettings.views.ajax_path;
+            $.each(drupalSettings.views.ajaxViews, function (views_dom_id) {
+                var views_parameters = Drupal.Views.parseQueryString(url);
+                var views_arguments = Drupal.Views.parseViewArgs(url, "search");
+                var views_settings = $.extend(
+                    {},
+                    Drupal.views.instances[views_dom_id].settings,
+                    views_arguments,
+                    views_parameters
+                );
+                var views_ajax_settings =
+                    Drupal.views.instances[views_dom_id].element_settings;
+                views_ajax_settings.submit = views_settings;
+                views_ajax_settings.url =
+                    view_path + "?" + $.param(Drupal.Views.parseQueryString(url));
+                Drupal.ajax(views_ajax_settings).execute();
             });
-        });
-
-          if (window.location.search.includes("display=") === true) {
-
-              $("li.pager__item a.pager__display").each(function () {
-                  $(this).parent().removeClass("is-active");
-                  $(this).removeClass("pager__link--is-active");
-                  if ($(this).text().trim().toLowerCase() === getParam(window.location.search, "display").trim().toLowerCase()) {
-                      $(this).addClass("pager__link--is-active");
-                  }
-              });
-          }
-
-          if (window.location.search.includes("items_per_page=") === true) {
-              $("li.pager__item a.pager__itemsperpage").each(function() {
-                  $(this).parent().removeClass("is-active");
-                  $(this).removeClass("pager__link--is-active");
-                  if ($(this).text().trim().toLowerCase() === getParam(window.location.search, "items_per_page").trim().toLowerCase()) {
-                      $(this).addClass("pager__link--is-active");
-                  }
-              });
-          }
-
-
-      }
-        function getParam(urlstring, param) {
-            var searchparam = new URLSearchParams(urlstring);
-            return searchparam.get(param);
         }
 
-      // Attach behavior to pager, summary, facet links.
-      $(once("new-window", "[data-drupal-pager-id], [data-drupal-facets-summary-id], [data-drupal-facet-id]"))
-        .find("a:not(.facet-item)")
-        .click(function (e) {
-          // Let ctrl/cmd click open in a new window.
-          if (e.shiftKey || e.ctrlKey || e.metaKey) {
-            return;
-          }
-          e.preventDefault();
+        // Update items_per_page links in pager
+        if (url.indexOf("items_per_page=") == -1) {
+            // append items_per_page
+            $("a.pager__itemsperpage").each(function( index ) {
+                var newUrl = url + "&items_per_page=" + $(this).html();
+                $(this).attr("href", newUrl);
+            });
+        }
+        else {
+            // replace existed items_per_page
+            var params = parseQueryString(url.split("?")[1]);
+            var newParams = [];
+            var existingDateQuery = false; // true if a date query already exists
 
-          // added to prevent page reload if a facet link is clicked (Ajax of view is enabled)
-          e.stopImmediatePropagation();
+            var links = {};
+            // update publication date in url if previously queried
+            for (var key in params) {
+                if (!params[key]) { // no search parameters in url
+                    break;
+                }
 
-          window.history.pushState(null, document.title, $(this).attr("href"));
+                // check for items_per_page query
+                if (!key.startsWith("items_per_page")) {
+                    newParams.push(key + "=" + params[key]);
+                }
+            }
+            var newParamsUrl = newParams.join('&');
+            $("a.pager__itemsperpage").each(function( index ) {
+                $(this).attr("href", url.split("?")[0] + '?' + newParamsUrl + "&items_per_page=" + $(this).html());
+            });
+        }
+
+
+
+        // Update display mode links in pager
+        if (url.indexOf("display=") == -1) {
+            // append items_per_page
+            $("a.pager__display").each(function( index ) {
+                var newUrl = url + "&display=" + $(this).attr('type');
+                $(this).attr("href", newUrl);
+            });
+
+        }
+        else {
+            // replace existed display
+            var params = parseQueryString(url.split("?")[1]);
+            var newParams = [];
+            var existingDateQuery = false; // true if a date query already exists
+
+            var links = {};
+            // update publication date in url if previously queried
+            for (var key in params) {
+                if (!params[key]) { // no search parameters in url
+                    break;
+                }
+
+                // check for display query
+                if (!key.startsWith("display")) {
+                    newParams.push(key + "=" + params[key]);
+                }
+            }
+            var newParamsUrl = newParams.join('&');
+            $("a.pager__display").each(function( index ) {
+
+                var value = $(this).attr('type');
+                $(this).attr("href", url.split("?")[0] + '?' + newParamsUrl + "&display=" + value);
+            });
+        }
+
+
+
+        // Replace filter, pager, summary, and facet blocks.
+        var blocks = {};
+        $(
+            "[class*='block-plugin-id--islandora-advanced-search-result-pager'], [class*='block-plugin-id--views-exposed-filter-block'], [class*='block-facets']"
+        ).each(function () {
+            var id = $(this).attr("id");
+            var block_id = id
+                .slice("block-".length, id.length)
+                .replace(/--.*$/g, "")
+                .replace(/-/g, "_");
+            blocks[block_id] = "#" + id;
         });
+        if (Object.keys(blocks).length > 0) {
+            Drupal.ajax({
+                url: Drupal.url("islandora-advanced-search-ajax-blocks"),
+                submit: {
+                    link: url,
+                    blocks: blocks,
+                },
+            }).execute();
+        }
+    }
 
-      // Trigger on sort change.
-      $(once('params-sort', '[data-drupal-pager-id] select[name="order"], .pager__sort select[name="order"]'))
-        .change(function () {
-          var href = window.location.href;
-          var params = Drupal.Views.parseQueryString(href);
+    // On location change reload all the blocks / ajax view.
+    window.addEventListener("pushstate", function (e) {
+        reload(window.location.href);
+    });
 
-          var selection = $(this).val();
-          var option = selection.split('_');
-          params.sort_order = option[option.length - 1].toUpperCase();
-          params.sort_by = selection.replace("_" + option[option.length - 1], "");
-          href = href.split("?")[0] + "?" + $.param(params);
-          window.history.pushState(null, document.title, href);
-        });
+    window.addEventListener("popstate", function (e) {
+        if (e.state != null) {
+            reload(window.location.href);
+        }
+    });
 
-    },
-  };
+    /**
+     * Push state on form/pager/facet change.
+     */
+    Drupal.behaviors.islandoraAdvancedSearchViewsAjax = {
+        attach: function (context, settings) {
+            window.historyInitiated = true;
+            // Remove existing behavior from form.
+            if (settings && settings.views && settings.views.ajaxViews) {
+                $.each(settings.views.ajaxViews, function (index, settings) {
+                    var exposed_form = $(
+                        "form#views-exposed-form-" +
+                        settings.view_name.replace(/_/g, "-") +
+                        "-" +
+                        settings.view_display_id.replace(/_/g, "-")
+                    );
+                    $(once('exposed-form',
+                        "form#views-exposed-form-" +
+                        settings.view_name.replace(/_/g, "-") +
+                        "-" +
+                        settings.view_display_id.replace(/_/g, "-")))
+                        .find("input[type=submit], input[type=image]")
+                        .not("[data-drupal-selector=edit-reset]")
+                        .each(function (index) {
+                            $(this).unbind("click");
+                            $(this).click(function (e) {
+                                // Let ctrl/cmd click open in a new window.
+                                if (e.shiftKey || e.ctrlKey || e.metaKey) {
+                                    return;
+                                }
+                                e.preventDefault();
+                                e.stopPropagation();
+                                var href = window.location.href;
+                                var params = Drupal.Views.parseQueryString(href);
+                                // Remove the page if set as submitting the form should always take
+                                // the user to the first page (facets do the same).
+                                delete params.page;
+                                // Include values from the form in the URL.
+                                $.each(exposed_form.serializeArray(), function () {
+                                    params[this.name] = this.value;
+                                });
+                                href = href.split("?")[0] + "?" + $.param(params);
+                                window.history.pushState(null, document.title, href);
+                            });
+                        });
+                });
+
+                if (window.location.search.includes("display=") === true) {
+
+                    $("li.pager__item a.pager__display").each(function () {
+                        $(this).parent().removeClass("is-active");
+                        $(this).removeClass("pager__link--is-active");
+                        if ($(this).attr('type').trim().toLowerCase() === getParam(window.location.search, "display").trim().toLowerCase()) {
+                            $(this).addClass("pager__link--is-active");
+                        }
+                    });
+                }
+
+                if (window.location.search.includes("items_per_page=") === true) {
+                    $("li.pager__item a.pager__itemsperpage").each(function() {
+                        $(this).parent().removeClass("is-active");
+                        $(this).removeClass("pager__link--is-active");
+                        if ($(this).text().trim().toLowerCase() === getParam(window.location.search, "items_per_page").trim().toLowerCase()) {
+                            $(this).addClass("pager__link--is-active");
+                        }
+                    });
+                }
+
+
+            }
+            function getParam(urlstring, param) {
+                var searchparam = new URLSearchParams(urlstring);
+                return searchparam.get(param);
+            }
+
+            // Attach behavior to pager, summary, facet links.
+            $(once("new-window", "[data-drupal-pager-id], [data-drupal-facets-summary-id], [data-drupal-facet-id]"))
+                .find("a:not(.facet-item)")
+                .click(function (e) {
+                    // Let ctrl/cmd click open in a new window.
+                    if (e.shiftKey || e.ctrlKey || e.metaKey) {
+                        return;
+                    }
+                    e.preventDefault();
+
+                    // added to prevent page reload if a facet link is clicked (Ajax of view is enabled)
+                    e.stopImmediatePropagation();
+
+                    window.history.pushState(null, document.title, $(this).attr("href"));
+                });
+
+            // Trigger on sort change.
+            $(once('params-sort', '[data-drupal-pager-id] select[name="order"], .pager__sort select[name="order"]'))
+                .change(function () {
+                    var href = window.location.href;
+                    var params = Drupal.Views.parseQueryString(href);
+
+                    var selection = $(this).val();
+                    var option = selection.split('_');
+                    params.sort_order = option[option.length - 1].toUpperCase();
+                    params.sort_by = selection.replace("_" + option[option.length - 1], "");
+                    href = href.split("?")[0] + "?" + $.param(params);
+                    window.history.pushState(null, document.title, href);
+                });
+
+        },
+    };
 })(jQuery, Drupal);

--- a/js/facets/facets-views-ajax.js
+++ b/js/facets/facets-views-ajax.js
@@ -4,46 +4,46 @@
  * Overrides the facets-view-ajax.js behavior from the 'facets' module.
  */
 (function ($, Drupal) {
-    "use strict";
+  "use strict";
 
-    // For each search view override display mode config (in SearchPagerResultBlock.php)
-    jQuery( document ).ready(function() {
-        handleDisplayMode();
-    });
+  // For each search view override display mode config (in SearchPagerResultBlock.php)
+  jQuery( document ).ready(function() {
+    handleDisplayMode(); 
+  });
 
-    jQuery(document).ajaxComplete(function() {
-        handleDisplayMode();
-    });
+  jQuery(document).ajaxComplete(function() {
+    handleDisplayMode();
+  });
 
-    // Generate events on push state.
-    (function (history) {
-        var pushState = history.pushState;
-        history.pushState = function (state, title, url) {
-            var ret = pushState.apply(this, arguments);
-            var event = new Event("pushstate");
-            window.dispatchEvent(event);
-            return ret;
-        };
-    })(window.history);
+  // Generate events on push state.
+  (function (history) {
+    var pushState = history.pushState;
+    history.pushState = function (state, title, url) {
+      var ret = pushState.apply(this, arguments);
+      var event = new Event("pushstate");
+      window.dispatchEvent(event);
+      return ret;
+    };
+  })(window.history);
 
-    function handleDisplayMode() {
-        var initial_display = jQuery('a.pager__link.pager__link--is-active.pager__display').attr('type');
-        if (initial_display == undefined) {
-            initial_display = jQuery("#override-default-display-mode").html();
-        }
-        if (jQuery('div.view.view-list').length == 1 && initial_display != "list") {
-            var search_view = jQuery('div.view.view-list');
-            search_view.removeClass("view-list");
-            search_view.addClass("view-grid");
-        }
-        if (jQuery('div.view.view-grid').length == 1 && initial_display != "grid") {
-            var search_view = jQuery('div.view.view-grid');
-            search_view.removeClass("view-grid");
-            search_view.addClass("view-list");
-        }
-    }
-
-    function parseQueryString( queryString ) {
+  function handleDisplayMode() {
+      var initial_display = jQuery('a.pager__link.pager__link--is-active.pager__display').attr('type');
+      if (initial_display == undefined) {
+        initial_display = jQuery("#override-default-display-mode").html();
+      }
+      if (jQuery('div.view.view-list').length == 1 && initial_display != "list") {
+        var search_view = jQuery('div.view.view-list');
+        search_view.removeClass("view-list");
+        search_view.addClass("view-grid");
+      }
+      if (jQuery('div.view.view-grid').length == 1 && initial_display != "grid") {
+        var search_view = jQuery('div.view.view-grid');
+        search_view.removeClass("view-grid");
+        search_view.addClass("view-list");
+      }
+  }
+  
+  function parseQueryString( queryString ) {
         var params = {}, queries, temp, i, l;
 
         // Split into key/value pairs
@@ -58,237 +58,237 @@
         return params;
     };
 
-    function reload(url) {
-        // Update View.
-        if (drupalSettings && drupalSettings.views && drupalSettings.views.ajaxViews) {
-            var view_path = drupalSettings.views.ajax_path;
-            $.each(drupalSettings.views.ajaxViews, function (views_dom_id) {
-                var views_parameters = Drupal.Views.parseQueryString(url);
-                var views_arguments = Drupal.Views.parseViewArgs(url, "search");
-                var views_settings = $.extend(
-                    {},
-                    Drupal.views.instances[views_dom_id].settings,
-                    views_arguments,
-                    views_parameters
-                );
-                var views_ajax_settings =
-                    Drupal.views.instances[views_dom_id].element_settings;
-                views_ajax_settings.submit = views_settings;
-                views_ajax_settings.url =
-                    view_path + "?" + $.param(Drupal.Views.parseQueryString(url));
-                Drupal.ajax(views_ajax_settings).execute();
-            });
-        }
-
-        // Update items_per_page links in pager
-        if (url.indexOf("items_per_page=") == -1) {
-            // append items_per_page
-            $("a.pager__itemsperpage").each(function( index ) {
-                var newUrl = url + "&items_per_page=" + $(this).html();
-                $(this).attr("href", newUrl);
-            });
-        }
-        else {
-            // replace existed items_per_page
-            var params = parseQueryString(url.split("?")[1]);
-            var newParams = [];
-            var existingDateQuery = false; // true if a date query already exists
-
-            var links = {};
-            // update publication date in url if previously queried
-            for (var key in params) {
-                if (!params[key]) { // no search parameters in url
-                    break;
-                }
-
-                // check for items_per_page query
-                if (!key.startsWith("items_per_page")) {
-                    newParams.push(key + "=" + params[key]);
-                }
-            }
-            var newParamsUrl = newParams.join('&');
-            $("a.pager__itemsperpage").each(function( index ) {
-                $(this).attr("href", url.split("?")[0] + '?' + newParamsUrl + "&items_per_page=" + $(this).html());
-            });
-        }
-
-
-
-        // Update display mode links in pager
-        if (url.indexOf("display=") == -1) {
-            // append items_per_page
-            $("a.pager__display").each(function( index ) {
-                var newUrl = url + "&display=" + $(this).attr('type');
-                $(this).attr("href", newUrl);
-            });
-
-        }
-        else {
-            // replace existed display
-            var params = parseQueryString(url.split("?")[1]);
-            var newParams = [];
-            var existingDateQuery = false; // true if a date query already exists
-
-            var links = {};
-            // update publication date in url if previously queried
-            for (var key in params) {
-                if (!params[key]) { // no search parameters in url
-                    break;
-                }
-
-                // check for display query
-                if (!key.startsWith("display")) {
-                    newParams.push(key + "=" + params[key]);
-                }
-            }
-            var newParamsUrl = newParams.join('&');
-            $("a.pager__display").each(function( index ) {
-
-                var value = $(this).attr('type');
-                $(this).attr("href", url.split("?")[0] + '?' + newParamsUrl + "&display=" + value);
-            });
-        }
-
-
-
-        // Replace filter, pager, summary, and facet blocks.
-        var blocks = {};
-        $(
-            "[class*='block-plugin-id--islandora-advanced-search-result-pager'], [class*='block-plugin-id--views-exposed-filter-block'], [class*='block-facets']"
-        ).each(function () {
-            var id = $(this).attr("id");
-            var block_id = id
-                .slice("block-".length, id.length)
-                .replace(/--.*$/g, "")
-                .replace(/-/g, "_");
-            blocks[block_id] = "#" + id;
-        });
-        if (Object.keys(blocks).length > 0) {
-            Drupal.ajax({
-                url: Drupal.url("islandora-advanced-search-ajax-blocks"),
-                submit: {
-                    link: url,
-                    blocks: blocks,
-                },
-            }).execute();
-        }
+  function reload(url) {
+    // Update View.
+    if (drupalSettings && drupalSettings.views && drupalSettings.views.ajaxViews) {
+      var view_path = drupalSettings.views.ajax_path;
+      $.each(drupalSettings.views.ajaxViews, function (views_dom_id) {
+        var views_parameters = Drupal.Views.parseQueryString(url);
+        var views_arguments = Drupal.Views.parseViewArgs(url, "search");
+        var views_settings = $.extend(
+          {},
+          Drupal.views.instances[views_dom_id].settings,
+          views_arguments,
+          views_parameters
+        );
+        var views_ajax_settings =
+          Drupal.views.instances[views_dom_id].element_settings;
+        views_ajax_settings.submit = views_settings;
+        views_ajax_settings.url =
+          view_path + "?" + $.param(Drupal.Views.parseQueryString(url));
+        Drupal.ajax(views_ajax_settings).execute();
+      });
     }
 
-    // On location change reload all the blocks / ajax view.
-    window.addEventListener("pushstate", function (e) {
-        reload(window.location.href);
-    });
+    // Update items_per_page links in pager 
+    if (url.indexOf("items_per_page=") == -1) { 
+      // append items_per_page
+      $("a.pager__itemsperpage").each(function( index ) {
+        var newUrl = url + "&items_per_page=" + $(this).html();
+        $(this).attr("href", newUrl);
+      });
+    } 
+    else { 
+      // replace existed items_per_page
+      var params = parseQueryString(url.split("?")[1]);
+      var newParams = [];
+      var existingDateQuery = false; // true if a date query already exists
 
-    window.addEventListener("popstate", function (e) {
-        if (e.state != null) {
-            reload(window.location.href);
+      var links = {};
+      // update publication date in url if previously queried
+      for (var key in params) {
+        if (!params[key]) { // no search parameters in url
+          break;
         }
+
+        // check for items_per_page query
+        if (!key.startsWith("items_per_page")) { 
+          newParams.push(key + "=" + params[key]);
+        }
+      }
+      var newParamsUrl = newParams.join('&');
+      $("a.pager__itemsperpage").each(function( index ) {
+        $(this).attr("href", url.split("?")[0] + '?' + newParamsUrl + "&items_per_page=" + $(this).html());
+      });
+    }
+
+
+
+    // Update display mode links in pager 
+    if (url.indexOf("display=") == -1) { 
+      // append items_per_page
+      $("a.pager__display").each(function( index ) {
+        var newUrl = url + "&display=" + $(this).attr('type');
+        $(this).attr("href", newUrl);
+      });
+      
+    } 
+    else { 
+      // replace existed display
+      var params = parseQueryString(url.split("?")[1]);
+      var newParams = [];
+      var existingDateQuery = false; // true if a date query already exists
+
+      var links = {};
+      // update publication date in url if previously queried
+      for (var key in params) {
+        if (!params[key]) { // no search parameters in url
+          break;
+        }
+
+        // check for display query
+        if (!key.startsWith("display")) { 
+          newParams.push(key + "=" + params[key]);
+        }
+      }
+      var newParamsUrl = newParams.join('&');
+      $("a.pager__display").each(function( index ) {
+
+        var value = $(this).attr('type');
+        $(this).attr("href", url.split("?")[0] + '?' + newParamsUrl + "&display=" + value);
+      });
+    }
+
+
+    
+    // Replace filter, pager, summary, and facet blocks.
+    var blocks = {};
+    $(
+      "[class*='block-plugin-id--islandora-advanced-search-result-pager'], [class*='block-plugin-id--views-exposed-filter-block'], [class*='block-facets']"
+    ).each(function () {
+      var id = $(this).attr("id");
+      var block_id = id
+        .slice("block-".length, id.length)
+        .replace(/--.*$/g, "")
+        .replace(/-/g, "_");
+      blocks[block_id] = "#" + id;
     });
-
-    /**
-     * Push state on form/pager/facet change.
-     */
-    Drupal.behaviors.islandoraAdvancedSearchViewsAjax = {
-        attach: function (context, settings) {
-            window.historyInitiated = true;
-            // Remove existing behavior from form.
-            if (settings && settings.views && settings.views.ajaxViews) {
-                $.each(settings.views.ajaxViews, function (index, settings) {
-                    var exposed_form = $(
-                        "form#views-exposed-form-" +
-                        settings.view_name.replace(/_/g, "-") +
-                        "-" +
-                        settings.view_display_id.replace(/_/g, "-")
-                    );
-                    $(once('exposed-form',
-                        "form#views-exposed-form-" +
-                        settings.view_name.replace(/_/g, "-") +
-                        "-" +
-                        settings.view_display_id.replace(/_/g, "-")))
-                        .find("input[type=submit], input[type=image]")
-                        .not("[data-drupal-selector=edit-reset]")
-                        .each(function (index) {
-                            $(this).unbind("click");
-                            $(this).click(function (e) {
-                                // Let ctrl/cmd click open in a new window.
-                                if (e.shiftKey || e.ctrlKey || e.metaKey) {
-                                    return;
-                                }
-                                e.preventDefault();
-                                e.stopPropagation();
-                                var href = window.location.href;
-                                var params = Drupal.Views.parseQueryString(href);
-                                // Remove the page if set as submitting the form should always take
-                                // the user to the first page (facets do the same).
-                                delete params.page;
-                                // Include values from the form in the URL.
-                                $.each(exposed_form.serializeArray(), function () {
-                                    params[this.name] = this.value;
-                                });
-                                href = href.split("?")[0] + "?" + $.param(params);
-                                window.history.pushState(null, document.title, href);
-                            });
-                        });
-                });
-
-                if (window.location.search.includes("display=") === true) {
-
-                    $("li.pager__item a.pager__display").each(function () {
-                        $(this).parent().removeClass("is-active");
-                        $(this).removeClass("pager__link--is-active");
-                        if ($(this).attr('type').trim().toLowerCase() === getParam(window.location.search, "display").trim().toLowerCase()) {
-                            $(this).addClass("pager__link--is-active");
-                        }
-                    });
-                }
-
-                if (window.location.search.includes("items_per_page=") === true) {
-                    $("li.pager__item a.pager__itemsperpage").each(function() {
-                        $(this).parent().removeClass("is-active");
-                        $(this).removeClass("pager__link--is-active");
-                        if ($(this).text().trim().toLowerCase() === getParam(window.location.search, "items_per_page").trim().toLowerCase()) {
-                            $(this).addClass("pager__link--is-active");
-                        }
-                    });
-                }
-
-
-            }
-            function getParam(urlstring, param) {
-                var searchparam = new URLSearchParams(urlstring);
-                return searchparam.get(param);
-            }
-
-            // Attach behavior to pager, summary, facet links.
-            $(once("new-window", "[data-drupal-pager-id], [data-drupal-facets-summary-id], [data-drupal-facet-id]"))
-                .find("a:not(.facet-item)")
-                .click(function (e) {
-                    // Let ctrl/cmd click open in a new window.
-                    if (e.shiftKey || e.ctrlKey || e.metaKey) {
-                        return;
-                    }
-                    e.preventDefault();
-
-                    // added to prevent page reload if a facet link is clicked (Ajax of view is enabled)
-                    e.stopImmediatePropagation();
-
-                    window.history.pushState(null, document.title, $(this).attr("href"));
-                });
-
-            // Trigger on sort change.
-            $(once('params-sort', '[data-drupal-pager-id] select[name="order"], .pager__sort select[name="order"]'))
-                .change(function () {
-                    var href = window.location.href;
-                    var params = Drupal.Views.parseQueryString(href);
-
-                    var selection = $(this).val();
-                    var option = selection.split('_');
-                    params.sort_order = option[option.length - 1].toUpperCase();
-                    params.sort_by = selection.replace("_" + option[option.length - 1], "");
-                    href = href.split("?")[0] + "?" + $.param(params);
-                    window.history.pushState(null, document.title, href);
-                });
-
+    if (Object.keys(blocks).length > 0) {
+      Drupal.ajax({
+        url: Drupal.url("islandora-advanced-search-ajax-blocks"),
+        submit: {
+          link: url,
+          blocks: blocks,
         },
-    };
+      }).execute();
+    }
+  }
+
+  // On location change reload all the blocks / ajax view.
+  window.addEventListener("pushstate", function (e) {
+    reload(window.location.href);
+  });
+
+  window.addEventListener("popstate", function (e) {
+    if (e.state != null) {
+      reload(window.location.href);
+    }
+  });
+
+  /**
+   * Push state on form/pager/facet change.
+   */
+  Drupal.behaviors.islandoraAdvancedSearchViewsAjax = {
+    attach: function (context, settings) {
+      window.historyInitiated = true;
+      // Remove existing behavior from form.
+      if (settings && settings.views && settings.views.ajaxViews) {
+        $.each(settings.views.ajaxViews, function (index, settings) {
+          var exposed_form = $(
+            "form#views-exposed-form-" +
+            settings.view_name.replace(/_/g, "-") +
+            "-" +
+            settings.view_display_id.replace(/_/g, "-")
+          );
+          $(once('exposed-form',
+            "form#views-exposed-form-" +
+            settings.view_name.replace(/_/g, "-") +
+            "-" +
+            settings.view_display_id.replace(/_/g, "-")))
+            .find("input[type=submit], input[type=image]")
+            .not("[data-drupal-selector=edit-reset]")
+            .each(function (index) {
+              $(this).unbind("click");
+              $(this).click(function (e) {
+                // Let ctrl/cmd click open in a new window.
+                if (e.shiftKey || e.ctrlKey || e.metaKey) {
+                  return;
+                }
+                e.preventDefault();
+                e.stopPropagation();
+                var href = window.location.href;
+                var params = Drupal.Views.parseQueryString(href);
+                // Remove the page if set as submitting the form should always take
+                // the user to the first page (facets do the same).
+                delete params.page;
+                // Include values from the form in the URL.
+                $.each(exposed_form.serializeArray(), function () {
+                  params[this.name] = this.value;
+                });
+                href = href.split("?")[0] + "?" + $.param(params);
+                window.history.pushState(null, document.title, href);
+              });
+            });
+        });
+
+          if (window.location.search.includes("display=") === true) {
+
+              $("li.pager__item a.pager__display").each(function () {
+                  $(this).parent().removeClass("is-active");
+                  $(this).removeClass("pager__link--is-active");
+                  if ($(this).attr('type').trim().toLowerCase() === getParam(window.location.search, "display").trim().toLowerCase()) {
+                      $(this).addClass("pager__link--is-active");
+                  }
+              });
+          }
+
+          if (window.location.search.includes("items_per_page=") === true) {
+              $("li.pager__item a.pager__itemsperpage").each(function() {
+                  $(this).parent().removeClass("is-active");
+                  $(this).removeClass("pager__link--is-active");
+                  if ($(this).text().trim().toLowerCase() === getParam(window.location.search, "items_per_page").trim().toLowerCase()) {
+                      $(this).addClass("pager__link--is-active");
+                  }
+              });
+          }
+
+
+      }
+        function getParam(urlstring, param) {
+            var searchparam = new URLSearchParams(urlstring);
+            return searchparam.get(param);
+        }
+
+      // Attach behavior to pager, summary, facet links.
+      $(once("new-window", "[data-drupal-pager-id], [data-drupal-facets-summary-id], [data-drupal-facet-id]"))
+        .find("a:not(.facet-item)")
+        .click(function (e) {
+          // Let ctrl/cmd click open in a new window.
+          if (e.shiftKey || e.ctrlKey || e.metaKey) {
+            return;
+          }
+          e.preventDefault();
+
+          // added to prevent page reload if a facet link is clicked (Ajax of view is enabled)
+          e.stopImmediatePropagation();
+
+          window.history.pushState(null, document.title, $(this).attr("href"));
+        });
+
+      // Trigger on sort change.
+      $(once('params-sort', '[data-drupal-pager-id] select[name="order"], .pager__sort select[name="order"]'))
+        .change(function () {
+          var href = window.location.href;
+          var params = Drupal.Views.parseQueryString(href);
+
+          var selection = $(this).val();
+          var option = selection.split('_');
+          params.sort_order = option[option.length - 1].toUpperCase();
+          params.sort_by = selection.replace("_" + option[option.length - 1], "");
+          href = href.split("?")[0] + "?" + $.param(params);
+          window.history.pushState(null, document.title, href);
+        });
+
+    },
+  };
 })(jQuery, Drupal);

--- a/src/Form/AdvancedSearchForm.php
+++ b/src/Form/AdvancedSearchForm.php
@@ -130,7 +130,7 @@ class AdvancedSearchForm extends FormBase {
      *   the enable or disable for Edismax Search checkbox
      */
     public static function getRecursive() {
-        return self::getConfig(SettingsForm::RECURSIVE_FIELD_FLAG, 0);
+        return self::getConfig(SettingsForm::RECURSIVE_FLAG, 0);
     }
     /**
      * Get the character to use for removing a facet from the query.

--- a/src/Form/AdvancedSearchForm.php
+++ b/src/Form/AdvancedSearchForm.php
@@ -21,451 +21,461 @@ use Symfony\Component\HttpFoundation\Request;
  * Form for building and Advanced Search Query.
  */
 class AdvancedSearchForm extends FormBase {
-  use GetConfigTrait;
+    use GetConfigTrait;
 
-  // Users can customize the operator to use font-awesome or some other icons.
-  // Its a limitation in the use of `input type=submit` rather than buttons in
-  // Drupal that we couldn't just rely on CSS.
-  // This is exposed in the module settings.
-  // @see https://www.drupal.org/project/drupal/issues/1671190
-  const DEFAULT_ADD_OP = '+';
-  const DEFAULT_REMOVE_OP = '-';
+    // Users can customize the operator to use font-awesome or some other icons.
+    // Its a limitation in the use of `input type=submit` rather than buttons in
+    // Drupal that we couldn't just rely on CSS.
+    // This is exposed in the module settings.
+    // @see https://www.drupal.org/project/drupal/issues/1671190
+    const DEFAULT_ADD_OP = '+';
+    const DEFAULT_REMOVE_OP = '-';
 
-  const AND_OP = 'AND';
-  const IS_OP = 'IS';
-  const NOT_OP = 'NOT';
-  const OR_OP = 'OR';
+    const AND_OP = 'AND';
+    const IS_OP = 'IS';
+    const NOT_OP = 'NOT';
+    const OR_OP = 'OR';
 
-  // These are also hard-coded in advanced_search.form.js.
-  const CONJUNCTION_FORM_FIELD = 'conjunction';
-  const SEARCH_FORM_FIELD = 'search';
-  const INCLUDE_FORM_FIELD = 'include';
-  const VALUE_FORM_FIELD = 'value';
+    // These are also hard-coded in advanced_search.form.js.
+    const CONJUNCTION_FORM_FIELD = 'conjunction';
+    const SEARCH_FORM_FIELD = 'search';
+    const INCLUDE_FORM_FIELD = 'include';
+    const VALUE_FORM_FIELD = 'value';
 
-  const AJAX_WRAPPER = 'advanced-search-ajax';
+    const AJAX_WRAPPER = 'advanced-search-ajax';
 
-  /**
-   * The current request.
-   *
-   * @var \Symfony\Component\HttpFoundation\Request
-   */
-  protected $request;
+    /**
+     * The current request.
+     *
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    protected $request;
 
-  /**
-   * The current route match.
-   *
-   * @var \Drupal\Core\Routing\RouteMatchInterface
-   */
-  protected $currentRouteMatch;
+    /**
+     * The current route match.
+     *
+     * @var \Drupal\Core\Routing\RouteMatchInterface
+     */
+    protected $currentRouteMatch;
 
-  /**
-   * Class constructor.
-   */
-  final public function __construct(Request $request, RouteMatchInterface $current_route_match) {
-    $this->request = $request;
-    $this->currentRouteMatch = $current_route_match;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('request_stack')->getMainRequest(),
-      $container->get('current_route_match')
-    );
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'advanced_search_form';
-  }
-
-  /**
-   * Get the character to use for adding a facet to the query.
-   *
-   * @return string
-   *   The character to use for adding an facet to the query.
-   */
-  public static function getAddOperator() {
-    return self::getConfig(SettingsForm::SEARCH_ADD_OPERATOR, self::DEFAULT_ADD_OP);
-  }
-
-  /**
-   * Get the character to use for removing a facet from the query.
-   *
-   * @return string
-   *   The character to use for removing an facet to the query.
-   */
-  public static function getRemoveOperator() {
-    return self::getConfig(SettingsForm::SEARCH_REMOVE_OPERATOR, self::DEFAULT_REMOVE_OP);
-  }
-
-  /**
-   * Get if Search All Fields checkbox is enabled or disable.
-   *
-   * @return bool
-   *   the enable or disable for Search All Fields checkbox
-   */
-  public static function getSearchAllFields() {
-    return self::getConfig(SettingsForm::SEARCH_ALL_FIELDS_FLAG, 0);
-  }
-
-  /**
-   * Get if Edismax Search checkbox is enabled or disable.
-   *
-   * @return bool
-   *   the enable or disable for Edismax Search checkbox
-   */
-  public static function getEdismaxSearch() {
-    return self::getConfig(SettingsForm::EDISMAX_SEARCH_FLAG, 0);
-  }
-
-  /**
-   * Get the character to use for removing a facet from the query.
-   *
-   * @return string
-   *   The character to use for removing an facet to the query.
-   */
-  public static function getEdismaxSearchLabel() {
-    return self::getConfig(SettingsForm::EDISMAX_SEARCH_LABEL, "All");
-  }
-
-  /**
-   * Convert the list of fields to select options.
-   *
-   * @param \Drupal\search_api\Item\FieldInterface[] $fields
-   *   The fields to convert to select options.
-   *
-   * @return array
-   *   Array of fields which can be searched where the key is the search field
-   *   identifier and the value is its human readable label.
-   */
-  protected function fieldOptions(array $fields) {
-    $options = [];
-    foreach ($fields as $field) {
-      $id = $field->getFieldIdentifier();
-      $options[$id] = $this->t($field->getLabel());
+    /**
+     * Class constructor.
+     */
+    final public function __construct(Request $request, RouteMatchInterface $current_route_match) {
+        $this->request = $request;
+        $this->currentRouteMatch = $current_route_match;
     }
-    return $options;
-  }
 
-  /**
-   * Gets possible include options for the given conjunction.
-   */
-  protected function includeOptions(string $conjunction) {
-    switch ($conjunction) {
-      case self::AND_OP:
-        return;
+    /**
+     * {@inheritdoc}
+     */
+    public static function create(ContainerInterface $container) {
+        return new static(
+            $container->get('request_stack')->getMainRequest(),
+            $container->get('current_route_match')
+        );
+    }
 
-      case self::OR_OP:
+    /**
+     * {@inheritdoc}
+     */
+    public function getFormId() {
+        return 'advanced_search_form';
+    }
+
+    /**
+     * Get the character to use for adding a facet to the query.
+     *
+     * @return string
+     *   The character to use for adding an facet to the query.
+     */
+    public static function getAddOperator() {
+        return self::getConfig(SettingsForm::SEARCH_ADD_OPERATOR, self::DEFAULT_ADD_OP);
+    }
+
+    /**
+     * Get the character to use for removing a facet from the query.
+     *
+     * @return string
+     *   The character to use for removing an facet to the query.
+     */
+    public static function getRemoveOperator() {
+        return self::getConfig(SettingsForm::SEARCH_REMOVE_OPERATOR, self::DEFAULT_REMOVE_OP);
+    }
+
+    /**
+     * Get if Search All Fields checkbox is enabled or disable.
+     *
+     * @return bool
+     *   the enable or disable for Search All Fields checkbox
+     */
+    public static function getSearchAllFields() {
+        return self::getConfig(SettingsForm::SEARCH_ALL_FIELDS_FLAG, 0);
+    }
+
+    /**
+     * Get if Edismax Search checkbox is enabled or disable.
+     *
+     * @return bool
+     *   the enable or disable for Edismax Search checkbox
+     */
+    public static function getEdismaxSearch() {
+        return self::getConfig(SettingsForm::EDISMAX_SEARCH_FLAG, 0);
+    }
+
+    /**
+     * Get if Collection Recursive Search checkbox is enabled or disabled.
+     *
+     * @return bool
+     *   the enable or disable for Edismax Search checkbox
+     */
+    public static function getRecursive() {
+        return self::getConfig(SettingsForm::RECURSIVE_FIELD_FLAG, 0);
+    }
+    /**
+     * Get the character to use for removing a facet from the query.
+     *
+     * @return string
+     *   The character to use for removing an facet to the query.
+     */
+    public static function getEdismaxSearchLabel() {
+        return self::getConfig(SettingsForm::EDISMAX_SEARCH_LABEL, "All");
+    }
+
+    /**
+     * Convert the list of fields to select options.
+     *
+     * @param \Drupal\search_api\Item\FieldInterface[] $fields
+     *   The fields to convert to select options.
+     *
+     * @return array
+     *   Array of fields which can be searched where the key is the search field
+     *   identifier and the value is its human readable label.
+     */
+    protected function fieldOptions(array $fields) {
+        $options = [];
+        foreach ($fields as $field) {
+            $id = $field->getFieldIdentifier();
+            $options[$id] = $field->getLabel();
+        }
+        return $options;
+    }
+
+    /**
+     * Gets possible include options for the given conjunction.
+     */
+    protected function includeOptions(string $conjunction) {
+        switch ($conjunction) {
+            case self::AND_OP:
+                return;
+
+            case self::OR_OP:
+                return [
+                    self::IS_OP => $this->t('is'),
+                ];
+        }
+    }
+
+    /**
+     * Default values to for a term.
+     */
+    protected function defaultTermValues(array $options) {
         return [
-          self::IS_OP => $this->t('is'),
+            self::CONJUNCTION_FORM_FIELD => self::AND_OP,
+            // First item in list is default.
+            self::SEARCH_FORM_FIELD => key($options),
+            self::INCLUDE_FORM_FIELD => self::IS_OP,
+            self::VALUE_FORM_FIELD => NULL,
         ];
     }
-  }
 
-  /**
-   * Default values to for a term.
-   */
-  protected function defaultTermValues(array $options) {
-    return [
-      self::CONJUNCTION_FORM_FIELD => self::AND_OP,
-      // First item in list is default.
-      self::SEARCH_FORM_FIELD => key($options),
-      self::INCLUDE_FORM_FIELD => self::IS_OP,
-      self::VALUE_FORM_FIELD => NULL,
-    ];
-  }
+    /**
+     * Process input to the from either URL parameters or from the form input.
+     */
+    protected function processInput(FormStateInterface $form_state, array $term_default_values) {
+        $input = $form_state->getUserInput();
+        $input['recursive'] = $input['recursive'] ?? self::getRecursive();
 
-  /**
-   * Process input to the from either URL parameters or from the form input.
-   */
-  protected function processInput(FormStateInterface $form_state, array $term_default_values) {
-    $input = $form_state->getUserInput();
-    $recursive = $input['recursive'] ?? NULL;
-    $term_values = isset($input['terms']) && is_array($input['terms']) ? $input['terms'] : [];
-    // Form was not submitted see if we can rebuild from query parameters.
-    $advanced_search_query = new AdvancedSearchQuery();
-    if (empty($term_values)) {
-      $terms = $advanced_search_query->getTerms($this->request);
-      foreach ($terms as $term) {
-        $term_values[] = $term->toUserInput();
-      }
+        $term_values = isset($input['terms']) && is_array($input['terms']) ? $input['terms'] : [];
+        // Form was not submitted see if we can rebuild from query parameters.
+        $advanced_search_query = new AdvancedSearchQuery();
+        if (empty($term_values)) {
+            $terms = $advanced_search_query->getTerms($this->request);
+            foreach ($terms as $term) {
+                $term_values[] = $term->toUserInput();
+            }
+        }
+        if (!isset($input['recursive'])) {
+            $recursive = $advanced_search_query->shouldRecurse($this->request);
+        }
+        // Form was submitted via +/- operators.
+        $trigger = $form_state->getTriggeringElement();
+        if ($trigger != NULL) {
+            $term_index = $trigger['#term_index'] ?? 0;
+            $value = $trigger['#value'] instanceof TranslatableMarkup ?
+                $trigger['#value']->getUntranslatedString() :
+                $trigger['#value'];
+            switch ($value) {
+                case $this->getAddOperator():
+                    // Insert after the term listed.
+                    array_splice($term_values, $term_index + 1, 0, [$term_default_values]);
+                    break;
+
+                case $this->getRemoveOperator():
+                    array_splice($term_values, $term_index, 1);
+                    break;
+
+                case "Reset":
+                    $recursive = FALSE;
+                    $term_values = [];
+                    break;
+
+                // Ignore unknown value for trigger.
+            }
+            // Place user input with updated values.
+            $input['terms'] = $term_values;
+            $input['recursive'] = $recursive;
+            $form_state->setUserInput($input);
+        }
+        return [$input['recursive'] , $term_values];
     }
-    if (!isset($input['recursive'])) {
-      $recursive = $advanced_search_query->shouldRecurse($this->request);
+
+    /**
+     * Gets the route name for the view display used to derive this forms block.
+     *
+     * @return string|null
+     *   The route name for the view display that was used to create this
+     *   forms block.
+     */
+    protected function getRouteName(FormStateInterface $form_state) {
+        $view = $form_state->get('view');
+        $display = $form_state->get('display');
+        $display_handlers = new DisplayPluginCollection($view->getExecutable(), Views::pluginManager('display'));
+        $display_handler = $display_handlers->get($display['id']);
+        if ($display_handler instanceof PathPluginBase) {
+            return $display_handler->getRouteName();
+        }
+        return NULL;
     }
-    // Form was submitted via +/- operators.
-    $trigger = $form_state->getTriggeringElement();
-    if ($trigger != NULL) {
-      $term_index = $trigger['#term_index'] ?? 0;
-      $value = $trigger['#value'] instanceof TranslatableMarkup ?
-        $trigger['#value']->getUntranslatedString() :
-        $trigger['#value'];
-      switch ($value) {
-        case $this->getAddOperator():
-          // Insert after the term listed.
-          array_splice($term_values, $term_index + 1, 0, [$term_default_values]);
-          break;
 
-        case $this->getRemoveOperator():
-          array_splice($term_values, $term_index, 1);
-          break;
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(array $form, FormStateInterface $form_state, View $view = NULL, array $display = [], array $fields = [], string $context_filter = NULL) {
+        // Keep reference to view and display as the submit handler may use them
+        // to redirect the user to the search page.
+        $form_state->set('view', $view);
+        $form_state->set('display', $display);
+        $route_name = $this->getRouteName($form_state);
+        $requires_redirect = $route_name ? $this->currentRouteMatch->getRouteName() !== $route_name : FALSE;
 
-        case "Reset":
-          $recursive = FALSE;
-          $term_values = [];
-          break;
-
-        // Ignore unknown value for trigger.
-      }
-      // Place user input with updated values.
-      $input['terms'] = $term_values;
-      $input['recursive'] = $recursive;
-      $form_state->setUserInput($input);
-    }
-    return [$recursive, $term_values];
-  }
-
-  /**
-   * Gets the route name for the view display used to derive this forms block.
-   *
-   * @return string|null
-   *   The route name for the view display that was used to create this
-   *   forms block.
-   */
-  protected function getRouteName(FormStateInterface $form_state) {
-    $view = $form_state->get('view');
-    $display = $form_state->get('display');
-    $display_handlers = new DisplayPluginCollection($view->getExecutable(), Views::pluginManager('display'));
-    $display_handler = $display_handlers->get($display['id']);
-    if ($display_handler instanceof PathPluginBase) {
-      return $display_handler->getRouteName();
-    }
-    return NULL;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function buildForm(array $form, FormStateInterface $form_state, View $view = NULL, array $display = [], array $fields = [], string $context_filter = NULL) {
-    // Keep reference to view and display as the submit handler may use them
-    // to redirect the user to the search page.
-    $form_state->set('view', $view);
-    $form_state->set('display', $display);
-    $route_name = $this->getRouteName($form_state);
-    $requires_redirect = $route_name ? $this->currentRouteMatch->getRouteName() !== $route_name : FALSE;
-
-    $form['#attached']['library'][] = 'advanced_search/advanced.search.form';
-    $form['#attached']['drupalSettings']['advanced_search_form'] = [
-      'id' => Html::getId($this->getFormId()),
-      'redirect' => $requires_redirect,
-      'query_parameter' => AdvancedSearchQuery::getQueryParameter(),
-      'recurse_parameter' => AdvancedSearchQuery::getRecurseParameter(),
-      'mapping' => [
-        self::CONJUNCTION_FORM_FIELD => AdvancedSearchQueryTerm::CONJUNCTION_QUERY_PARAMETER,
-        self::SEARCH_FORM_FIELD => AdvancedSearchQueryTerm::FIELD_QUERY_PARAMETER,
-        self::INCLUDE_FORM_FIELD => AdvancedSearchQueryTerm::INCLUDE_QUERY_PARAMETER,
-        self::VALUE_FORM_FIELD => AdvancedSearchQueryTerm::VALUE_QUERY_PARAMETER,
-      ],
-    ];
-
-    $options = (self::getEdismaxSearch() && self::getSearchAllFields()) ? ["all" => $this->t("@label", ["@label" => $this->t(self::getEdismaxSearchLabel())])] + $this->fieldOptions($fields) : $this->fieldOptions($fields);
-    $term_default_values = $this->defaultTermValues($options);
-    [$recursive, $term_values] = $this->processInput($form_state, $term_default_values);
-    $i = 0;
-    $term_elements = [];
-    $total_terms = count($term_values);
-    $block_class_prefix = str_replace('_', '-', $this->getFormId());
-    do {
-      // Either specified by the user in the request or use the default.
-      $first = $i == 0;
-      $term_value = !empty($term_values) ? array_shift($term_values) : $term_default_values;
-      $conjunction = $term_value[self::CONJUNCTION_FORM_FIELD] ?? $term_default_values[self::CONJUNCTION_FORM_FIELD];
-      $term_elements[] = [
-        // Only show on terms after the first.
-        self::CONJUNCTION_FORM_FIELD => $first ? NULL : [
-          '#type' => 'select',
-          '#attributes' => [
-            'aria-label' => $this->t("Select search condition"),
-          ],
-          '#options' => [
-            self::AND_OP => $this->t('and'),
-            self::OR_OP => $this->t('or'),
-          ],
-          '#default_value' => $conjunction,
-          '#theme_wrappers' => [],
-        ],
-        self::SEARCH_FORM_FIELD => [
-          '#type' => 'select',
-          '#attributes' => [
-            'aria-label' => $this->t("Select search field"),
-          ],
-          '#options' => $options,
-          '#default_value' => $term_value[self::SEARCH_FORM_FIELD],
-          '#theme_wrappers' => [],
-        ],
-        self::INCLUDE_FORM_FIELD => [
-          '#type' => 'select',
-          '#attributes' => [
-            'aria-label' => $this->t("Select search operator"),
-          ],
-          '#options' => [
-            self::IS_OP => $this->t('is'),
-            self::NOT_OP => $this->t('is not'),
-          ],
-          '#default_value' => $term_value[self::INCLUDE_FORM_FIELD],
-          // Show only when conjunction is 'AND' as 'OR NOT' is not supported
-          // by solr and will be converted to 'AND NOT'.
-          '#states' => [
-            'visible' => [
-              ':input[name="terms[' . $i . '][' . self::CONJUNCTION_FORM_FIELD . ']"]' => ['value' => self::AND_OP],
+        $form['#attached']['library'][] = 'advanced_search/advanced.search.form';
+        $form['#attached']['drupalSettings']['advanced_search_form'] = [
+            'id' => Html::getId($this->getFormId()),
+            'redirect' => $requires_redirect,
+            'query_parameter' => AdvancedSearchQuery::getQueryParameter(),
+            'recurse_parameter' => AdvancedSearchQuery::getRecurseParameter(),
+            'mapping' => [
+                self::CONJUNCTION_FORM_FIELD => AdvancedSearchQueryTerm::CONJUNCTION_QUERY_PARAMETER,
+                self::SEARCH_FORM_FIELD => AdvancedSearchQueryTerm::FIELD_QUERY_PARAMETER,
+                self::INCLUDE_FORM_FIELD => AdvancedSearchQueryTerm::INCLUDE_QUERY_PARAMETER,
+                self::VALUE_FORM_FIELD => AdvancedSearchQueryTerm::VALUE_QUERY_PARAMETER,
             ],
-          ],
-          '#theme_wrappers' => [],
-        ],
-        // Just markup to show when 'include' is not alterable due to the
-        // selected 'conjunction'. Hide for the first term.
-        'is' => $first ? NULL : [
-          '#type' => 'container',
-          '#attributes' => ['style' => 'display:inline;'],
-          '#states' => [
-            'visible' => [
-              ':input[name="terms[' . $i . '][' . self::CONJUNCTION_FORM_FIELD . ']"]' => ['value' => self::OR_OP],
-            ],
-          ],
-          /*'content' => [
-            '#markup' => $this->t('is'),
-          ],*/
-          '#theme_wrappers' => [],
-        ],
-        self::VALUE_FORM_FIELD => [
-          '#type' => 'textfield',
-          '#attributes' => [
-            'aria-label' => $this->t("Enter a search term"),
-          ],
-          '#default_value' => $term_value[self::VALUE_FORM_FIELD],
-          '#theme_wrappers' => [],
-        ],
-        'actions' => [
-          '#type' => 'container',
-          'add' => [
+        ];
+
+        $options = (self::getEdismaxSearch() && self::getSearchAllFields()) ? ["all" => $this->t("@label", ["@label" => self::getEdismaxSearchLabel()])] + $this->fieldOptions($fields) : $this->fieldOptions($fields);
+        $term_default_values = $this->defaultTermValues($options);
+        [$recursive, $term_values] = $this->processInput($form_state, $term_default_values);
+        $i = 0;
+        $term_elements = [];
+        $total_terms = count($term_values);
+        $block_class_prefix = str_replace('_', '-', $this->getFormId());
+        do {
+            // Either specified by the user in the request or use the default.
+            $first = $i == 0;
+            $term_value = !empty($term_values) ? array_shift($term_values) : $term_default_values;
+            $conjunction = $term_value[self::CONJUNCTION_FORM_FIELD] ?? $term_default_values[self::CONJUNCTION_FORM_FIELD];
+            $term_elements[] = [
+                // Only show on terms after the first.
+                self::CONJUNCTION_FORM_FIELD => $first ? NULL : [
+                    '#type' => 'select',
+                    '#attributes' => [
+                        'aria-label' => $this->t("Select search condition"),
+                    ],
+                    '#options' => [
+                        self::AND_OP => $this->t('and'),
+                        self::OR_OP => $this->t('or'),
+                    ],
+                    '#default_value' => $conjunction,
+                    '#theme_wrappers' => [],
+                ],
+                self::SEARCH_FORM_FIELD => [
+                    '#type' => 'select',
+                    '#attributes' => [
+                        'aria-label' => $this->t("Select search field"),
+                    ],
+                    '#options' => $options,
+                    '#default_value' => $term_value[self::SEARCH_FORM_FIELD],
+                    '#theme_wrappers' => [],
+                ],
+                self::INCLUDE_FORM_FIELD => [
+                    '#type' => 'select',
+                    '#attributes' => [
+                        'aria-label' => $this->t("Select search operator"),
+                    ],
+                    '#options' => [
+                        self::IS_OP => $this->t('is'),
+                        self::NOT_OP => $this->t('is not'),
+                    ],
+                    '#default_value' => $term_value[self::INCLUDE_FORM_FIELD],
+                    // Show only when conjunction is 'AND' as 'OR NOT' is not supported
+                    // by solr and will be converted to 'AND NOT'.
+                    '#states' => [
+                        'visible' => [
+                            ':input[name="terms[' . $i . '][' . self::CONJUNCTION_FORM_FIELD . ']"]' => ['value' => self::AND_OP],
+                        ],
+                    ],
+                    '#theme_wrappers' => [],
+                ],
+                // Just markup to show when 'include' is not alterable due to the
+                // selected 'conjunction'. Hide for the first term.
+                'is' => $first ? NULL : [
+                    '#type' => 'container',
+                    '#attributes' => ['style' => 'display:inline;'],
+                    '#states' => [
+                        'visible' => [
+                            ':input[name="terms[' . $i . '][' . self::CONJUNCTION_FORM_FIELD . ']"]' => ['value' => self::OR_OP],
+                        ],
+                    ],
+                    /*'content' => [
+                      '#markup' => $this->t('is'),
+                    ],*/
+                    '#theme_wrappers' => [],
+                ],
+                self::VALUE_FORM_FIELD => [
+                    '#type' => 'textfield',
+                    '#attributes' => [
+                        'aria-label' => $this->t("Enter a search term"),
+                    ],
+                    '#default_value' => $term_value[self::VALUE_FORM_FIELD],
+                    '#theme_wrappers' => [],
+                ],
+                'actions' => [
+                    '#type' => 'container',
+                    'add' => [
+                        '#type' => 'button',
+                        '#value' => $this->getAddOperator(),
+                        '#name' => 'add-term-' . $i,
+                        '#term_index' => $i,
+                        '#attributes' => [
+                            'class' => [$block_class_prefix . '__add', 'fa'],
+                        ],
+                        '#ajax' => [
+                            'callback' => [$this, 'ajaxCallback'],
+                            'wrapper' => self::AJAX_WRAPPER,
+                            'progress' => [
+                                'type' => 'none',
+                            ],
+                        ],
+                    ],
+                    'remove' => $total_terms <= 1 ? NULL : [
+                        '#type' => 'button',
+                        '#value' => $this->getRemoveOperator(),
+                        '#name' => 'remove-term-' . $i,
+                        '#term_index' => $i,
+                        '#attributes' => [
+                            'class' => [$block_class_prefix . '__remove', 'fa'],
+                            'aria-label' => $this->t("Remove"),
+                        ],
+                        '#ajax' => [
+                            'callback' => [$this, 'ajaxCallback'],
+                            'wrapper' => self::AJAX_WRAPPER,
+                            'progress' => [
+                                'type' => 'none',
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+            $i++;
+        } while (!empty($term_values));
+
+        $form['ajax'] = [
+            '#type' => 'container',
+            '#attributes' => ['id' => self::AJAX_WRAPPER],
+            'terms' => array_merge([
+                '#tree' => TRUE,
+                '#type' => 'container',
+            ], $term_elements),
+        ];
+
+        if ($context_filter != NULL) {
+            $form['ajax']['recursive'] = [
+                '#type' => 'checkbox',
+                '#title' => $this->t('Include Sub-Collections'),
+                '#default_value' => $recursive,
+            ];
+        }
+        $form['reset'] = [
             '#type' => 'button',
-            '#value' => $this->getAddOperator(),
-            '#name' => 'add-term-' . $i,
-            '#term_index' => $i,
+            '#value' => $this->t('Reset'),
             '#attributes' => [
-              'class' => [$block_class_prefix . '__add', 'fa'],
+                'class' => [$block_class_prefix . '__reset'],
             ],
             '#ajax' => [
-              'callback' => [$this, 'ajaxCallback'],
-              'wrapper' => self::AJAX_WRAPPER,
-              'progress' => [
-                'type' => 'none',
-              ],
+                'callback' => [$this, 'ajaxCallback'],
+                'wrapper' => self::AJAX_WRAPPER,
+                'progress' => [
+                    'type' => 'none',
+                ],
             ],
-          ],
-          'remove' => $total_terms <= 1 ? NULL : [
-            '#type' => 'button',
-            '#value' => $this->getRemoveOperator(),
-            '#name' => 'remove-term-' . $i,
-            '#term_index' => $i,
+        ];
+        $form['submit'] = [
+            '#type' => 'submit',
+            '#value' => $this->t('Search'),
             '#attributes' => [
-              'class' => [$block_class_prefix . '__remove', 'fa'],
-              'aria-label' => $this->t("Remove"),
+                'class' => [$block_class_prefix . '__search'],
             ],
-            '#ajax' => [
-              'callback' => [$this, 'ajaxCallback'],
-              'wrapper' => self::AJAX_WRAPPER,
-              'progress' => [
-                'type' => 'none',
-              ],
-            ],
-          ],
-        ],
-      ];
-      $i++;
-    } while (!empty($term_values));
-
-    $form['ajax'] = [
-      '#type' => 'container',
-      '#attributes' => ['id' => self::AJAX_WRAPPER],
-      'terms' => array_merge([
-        '#tree' => TRUE,
-        '#type' => 'container',
-      ], $term_elements),
-    ];
-
-    if ($context_filter != NULL) {
-      $form['ajax']['recursive'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t('Include Sub-Collections'),
-        '#default_value' => $recursive,
-      ];
+        ];
+        return $form;
     }
-    $form['reset'] = [
-      '#type' => 'button',
-      '#value' => $this->t('Reset'),
-      '#attributes' => [
-        'class' => [$block_class_prefix . '__reset'],
-      ],
-      '#ajax' => [
-        'callback' => [$this, 'ajaxCallback'],
-        'wrapper' => self::AJAX_WRAPPER,
-        'progress' => [
-          'type' => 'none',
-        ],
-      ],
-    ];
-    $form['submit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Search'),
-      '#attributes' => [
-        'class' => [$block_class_prefix . '__search'],
-      ],
-    ];
-    return $form;
-  }
 
-  /**
-   * Builds an Advanced Search Query Url from the submitted form values.
-   */
-  protected function buildUrl(FormStateInterface $form_state) {
-    $terms = [];
-    $values = $form_state->getValues();
-    foreach ($values['terms'] as $term) {
-      $terms[] = AdvancedSearchQueryTerm::fromUserInput($term);
+    /**
+     * Builds an Advanced Search Query Url from the submitted form values.
+     */
+    protected function buildUrl(FormStateInterface $form_state) {
+        $terms = [];
+        $values = $form_state->getValues();
+        foreach ($values['terms'] as $term) {
+            $terms[] = AdvancedSearchQueryTerm::fromUserInput($term);
+        }
+        $terms = array_filter($terms);
+        $recurse = filter_var($values['recursive'] ?? FALSE, FILTER_VALIDATE_BOOLEAN);
+        $route = $this->getRouteName($form_state);
+        $advanced_search_query = new AdvancedSearchQuery();
+        return $advanced_search_query->toUrl($this->request, $terms, $recurse, $route);
     }
-    $terms = array_filter($terms);
-    $recurse = filter_var($values['recursive'] ?? FALSE, FILTER_VALIDATE_BOOLEAN);
-    $route = $this->getRouteName($form_state);
-    $advanced_search_query = new AdvancedSearchQuery();
-    return $advanced_search_query->toUrl($this->request, $terms, $recurse, $route);
-  }
 
-  /**
-   * Callback for adding / removing terms from the search.
-   */
-  public function ajaxCallback(array &$form, FormStateInterface $form_state) {
-    return $form['ajax'];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
-    $trigger = (string) $form_state->getTriggeringElement()['#value'];
-    switch ($trigger) {
-      case $this->t('Search'):
-        $form_state->setRedirectUrl($this->buildUrl($form_state));
-        break;
-
-      default:
-        $form_state->setRebuild();
+    /**
+     * Callback for adding / removing terms from the search.
+     */
+    public function ajaxCallback(array &$form, FormStateInterface $form_state) {
+        return $form['ajax'];
     }
-  }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function submitForm(array &$form, FormStateInterface $form_state) {
+        $trigger = (string) $form_state->getTriggeringElement()['#value'];
+        switch ($trigger) {
+            case $this->t('Search'):
+                $form_state->setRedirectUrl($this->buildUrl($form_state));
+                break;
+
+            default:
+                $form_state->setRebuild();
+        }
+    }
 
 }

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -12,275 +12,222 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Config form for Islandora Advanced Search settings.
  */
-class SettingsForm extends ConfigFormBase
-{
+class SettingsForm extends ConfigFormBase {
 
-  use GetConfigTrait;
+    use GetConfigTrait;
 
-  const CONFIG_NAME = 'advanced_search.settings';
-  const SEARCH_QUERY_PARAMETER = 'search_query_parameter';
-  const SEARCH_RECURSIVE_PARAMETER = 'search_recursive_parameter';
-  const SEARCH_ADD_OPERATOR = 'search_add_operator';
-  const SEARCH_REMOVE_OPERATOR = 'search_remove_operator';
-  const FACET_TRUNCATE = 'facet_truncate';
-  const EDISMAX_SEARCH_FLAG = 'lucene_on_off';
-  const EDISMAX_SEARCH_LABEL = 'lucene_label';
-  const SEARCH_ALL_FIELDS_FLAG = 'all_fields_on_off';
-  const DISPLAY_LIST_FLAG = 'list_on_off';
-  const DISPLAY_GRID_FLAG = 'grid_on_off';
-  const DISPLAY_DEFAULT = 'default-display-mode';
-  const QUERY_FIELDS = 'query_fields';
+    const CONFIG_NAME = 'advanced_search.settings';
+    const SEARCH_QUERY_PARAMETER = 'search_query_parameter';
+    const SEARCH_RECURSIVE_PARAMETER = 'search_recursive_parameter';
+    const SEARCH_ADD_OPERATOR = 'search_add_operator';
+    const SEARCH_REMOVE_OPERATOR = 'search_remove_operator';
+    const FACET_TRUNCATE = 'facet_truncate';
+    const EDISMAX_SEARCH_FLAG = 'lucene_on_off';
+    const EDISMAX_SEARCH_LABEL = 'lucene_label';
+    const SEARCH_ALL_FIELDS_FLAG = 'all_fields_on_off';
+    const RECURSIVE_FIELD_FLAG = 'recursive';
+    const DISPLAY_LIST_FLAG = 'list_on_off';
+    const DISPLAY_GRID_FLAG = 'grid_on_off';
+    const DISPLAY_DEFAULT = 'default-display-mode';
 
-  /**
-   * Constructs a \Drupal\system\ConfigFormBase object.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The factory for configuration objects.
-   */
-  final public function __construct(ConfigFactoryInterface $config_factory)
-  {
-    $this->setConfigFactory($config_factory);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container)
-  {
-    return new static($container->get('config.factory'));
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId()
-  {
-    return 'advanced_search_settings_form';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getEditableConfigNames()
-  {
-    return [
-      self::CONFIG_NAME,
-    ];
-  }
-
-  /**
-   * Get available fields from all Search API indexes.
-   *
-   * @return array
-   *   An associative array of field identifiers to field labels.
-   */
-  protected function getAvailableFields()
-  {
-    $field_options = [];
-
-    // Load all Search API indexes.
-    $index_storage = \Drupal::entityTypeManager()->getStorage('search_api_index');
-    $indexes = $index_storage->loadMultiple();
-
-    foreach ($indexes as $index) {
-      $fields = $index->getFields();
-      foreach ($fields as $field_id => $field) {
-        $field_options[$field_id] = $field->getLabel() . " (" . $field_id . ")";
-      }
+    /**
+     * Constructs a \Drupal\system\ConfigFormBase object.
+     *
+     * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+     *   The factory for configuration objects.
+     */
+    final public function __construct(ConfigFactoryInterface $config_factory) {
+        $this->setConfigFactory($config_factory);
     }
 
-    return $field_options;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public static function create(ContainerInterface $container) {
+        return new static($container->get('config.factory'));
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function buildForm(array $form, FormStateInterface $form_state)
-  {
-    $form['eDisMax'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t('Advanced Search Block'),
-      '#weight' => -1,
-    ];
-    $form['eDisMax']['advanced-search-block-description'] = [
-      '#markup' => $this->t('Advanced Search Blocks are available in the Blocks interface for each Search API view. When placing an Advanced Search Block, you can configure the fields that are used for field-based search and whether a "recursive" search is available.  The following settings apply to all Advanced Search blocks.'),
-      '#weight' => -2,
-    ];
+    /**
+     * {@inheritdoc}
+     */
+    public function getFormId() {
+        return 'advanced_search_settings_form';
+    }
 
-    $isEDismax = \Drupal::config(SettingsForm::CONFIG_NAME)->get(self::EDISMAX_SEARCH_FLAG);
-    $form['eDisMax'][self::EDISMAX_SEARCH_FLAG] = [
-      '#type' => 'checkbox',
-      '#title' => $this
-        ->t('Enable Extended DisMax Query.'),
-      '#description' => $this->t('<ul> <li>When enabled, all queries using an Advanced Search Block use the Extended Dismax (eDisMax) query processor.</li>
+    /**
+     * {@inheritdoc}
+     */
+    protected function getEditableConfigNames() {
+        return [
+            self::CONFIG_NAME,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(array $form, FormStateInterface $form_state) {
+        $form['eDisMax'] = [
+            '#type' => 'fieldset',
+            '#title' => $this->t('Advanced Search Block'),
+            '#weight' => -1,
+        ];
+        $form['eDisMax']['advanced-search-block-description'] = [
+            '#markup' => $this->t("Advanced Search Blocks are available in the Blocks interface for each Search API view. When placing an Advanced Search Block, you can configure the fields that are used for field-based search and whether a “recursive” search is available.  The following settings apply to all Advanced Search blocks."),
+            '#weight' => -2,
+        ];
+
+        $isEDismax = \Drupal::config(SettingsForm::CONFIG_NAME)->get(self::EDISMAX_SEARCH_FLAG);
+        $form['eDisMax'][self::EDISMAX_SEARCH_FLAG] = [
+            '#type' => 'checkbox',
+            '#title' => $this
+                ->t('Enable Extended DisMax Query.'),
+            '#description' => $this->t('<ul> <li>When enabled, all queries using an Advanced Search Block use the Extended Dismax (eDisMax) query processor.</li>
         <li>This setting must be enabled for the “Simple Search Block” to function. </li>
         <li>If enabled, the “Simple Search Block”/”Advanced Search Blocks” support:
-           <ul> 
+           <ul>
             <li>queries that include AND, OR, NOT, -, and + (user documentation needed)</li>
             <li>Wildcard operator *</li>
             <li>Words in query are treated as distinct words. They are combined using OR unless the user specifies using AND/NOT in their query.</li>
            </ul>
           </li>
         </ul>'),
-      '#default_value' => $isEDismax ?? 1,
-    ];
+            '#default_value' => $isEDismax ?? 1,
+        ];
 
-    $form['eDisMax']['textfields_container'] = [
-      '#type' => 'container',
-      '#attributes' => ['id' => 'edismax-container'],
-    ];
+        $form['eDisMax']['textfields_container'] = [
+            '#type' => 'container',
+            '#attributes' => ['id' => 'edismax-container'],
+        ];
 
-    $form['eDisMax']['textfields_container'][self::SEARCH_ALL_FIELDS_FLAG] = [
-      '#type' => 'checkbox',
-      '#title' => $this
-        ->t('Enable searching all fields'),
-      '#description' => $this->t('<ul>
+        $form['eDisMax']['textfields_container'][self::SEARCH_ALL_FIELDS_FLAG] = [
+            '#type' => 'checkbox',
+            '#title' => $this
+                ->t('Enable searching all fields'),
+            '#description' => $this->t('<ul>
           <li>This makes an additional option visible in all Advanced Search Blocks, which searches across all fields. Its label is configured below.</li>
-          <li>This setting must be enabled for the "Simple Search Block" to function.</li>
+          <li>This setting must be enabled for the “Simple Search Block” to function.</li>
         </ul>'),
-      '#default_value' => self::getConfig(self::SEARCH_ALL_FIELDS_FLAG, 0),
-    ];
-    $form['eDisMax']['textfields_container'][self::EDISMAX_SEARCH_LABEL] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('If enabled, set the label for the option of searching all fields'),
-      '#description' => $this->t('E.g. keyword.'),
-      '#default_value' => self::getConfig(self::EDISMAX_SEARCH_LABEL, "Keyword"),
-    ];
+            '#default_value' => self::getConfig(self::SEARCH_ALL_FIELDS_FLAG, 0),
+        ];
 
-    // Query Fields Block 
-    $form['query_fields_block'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t('Query Fields'),
-      '#weight' => -0.5,
-    ];
+        $form['eDisMax']['textfields_container'][self::RECURSIVE_FIELD_FLAG] = [
+            '#type' => 'checkbox',
+            '#title' => $this
+                ->t('Search collections recursively by default.'),
+            '#description' => $this->t('<ul>
+          <li>Select whether subcollections are searched by default.</li>
+          <li>The user can override this setting.</li>
+        </ul>'),
+            '#default_value' => self::getConfig(self::RECURSIVE_FIELD_FLAG, 0),
+        ];
+        $form['eDisMax']['textfields_container'][self::EDISMAX_SEARCH_LABEL] = [
+            '#type' => 'textfield',
+            '#title' => $this->t('If enabled, set the label for the option of searching all fields'),
+            '#description' => $this->t('E.g. keyword.'),
+            '#default_value' => self::getConfig(self::EDISMAX_SEARCH_LABEL, "Keyword"),
+        ];
 
-    $field_options = $this->getAvailableFields();
 
-    $base_url = \Drupal::request()->getSchemeAndHttpHost();
-    $query_fields_description = $this->t('Select which fields should be queried when searching all fields label (keyword) chosen. If no fields are selected, <a href="@fields_url" target="_blank">all fields will be searched</a>.', [
-      '@fields_url' => $base_url . '/admin/config/search/search-api/index/default_solr_index_islandora_lite/fields',
-    ]);
 
-    $form['query_fields_block']['query_fields_description'] = [
-      '#type' => 'item',
-      '#markup' => '<div style=" background: #f0f0f0; border-left: 4px solid #0074bd;">' . $query_fields_description . '</div>',
-    ];
+        $form['display-mode'] = [
+            '#type' => 'fieldset',
+            '#title' => $this->t("Pager Block"),
+        ];
+        $form['display-mode']['pager-block-description'] = [
+            '#markup' => $this->t("Pager blocks are available in the Blocks interface for each Search API view.  The following settings apply for all Pager blocks."),
+        ];
 
-    $form['query_fields_block']['query_fields_wrapper'] = [
-      '#type' => 'container',
-      '#attributes' => [
-        'style' => 'max-height: 350px; overflow-y: auto; border: 1px solid #ccc; padding: 10px; background: #f9f9f9;',
-      ],
-    ];
+        $form['display-mode'][self::DISPLAY_LIST_FLAG] = [
+            '#type' => 'checkbox',
+            '#title' => $this
+                ->t('Expose "List view" option.'),
+            '#default_value' => self::getConfig(self::DISPLAY_LIST_FLAG, 0),
+        ];
 
-    $form['query_fields_block']['query_fields_wrapper'][self::QUERY_FIELDS] = [
-      '#type' => 'checkboxes',
-      '#title' => $this->t('Select fields to query'),
-      '#options' => $field_options,
-      '#default_value' => self::getConfig(self::QUERY_FIELDS, []),
-    ];
+        $form['display-mode'][self::DISPLAY_GRID_FLAG] = [
+            '#type' => 'checkbox',
+            '#title' => $this
+                ->t('Expose "Grid view" option.'),
+            '#default_value' => self::getConfig(self::DISPLAY_GRID_FLAG, 0),
+        ];
 
-    $form['display-mode'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t("Pager Block"),
-    ];
-    $form['display-mode']['pager-block-description'] = [
-      '#markup' => $this->t("Pager blocks are available in the Blocks interface for each Search API view.  The following settings apply for all Pager blocks."),
-    ];
+        $form['display-mode'][self::DISPLAY_DEFAULT] = [
+            '#type' => 'select',
+            '#title' => $this
+                ->t('Default view mode:'),
+            '#options' => [
+                'list' => 'List',
+                'grid' => 'Grid',
+            ],
+            '#default_value' => self::getConfig(self::DISPLAY_DEFAULT, 'grid'),
+        ];
 
-    $form['display-mode'][self::DISPLAY_LIST_FLAG] = [
-      '#type' => 'checkbox',
-      '#title' => $this
-        ->t('Expose "List view" option.'),
-      '#default_value' => self::getConfig(self::DISPLAY_LIST_FLAG, 0),
-    ];
+        $form += [
+            'search' => [
+                '#type' => 'fieldset',
+                '#title' => $this->t('Advanced Search'),
+                self::SEARCH_QUERY_PARAMETER => [
+                    '#type' => 'textfield',
+                    '#title' => $this->t('Search Query Parameter'),
+                    '#description' => $this->t('The url parameter in which the advanced search query is stored.'),
+                    '#default_value' => AdvancedSearchQuery::getQueryParameter(),
+                ],
+                self::SEARCH_RECURSIVE_PARAMETER => [
+                    '#type' => 'textfield',
+                    '#title' => $this->t('Recurse Query Parameter'),
+                    '#description' => $this->t('The url parameter which can toggle recursive search.'),
+                    '#default_value' => AdvancedSearchQuery::getRecurseParameter(),
+                ],
+                self::SEARCH_ADD_OPERATOR => [
+                    '#type' => 'textfield',
+                    '#title' => $this->t('Facet Add Operator'),
+                    '#description' => $this->t('Users can customize the operator for adding facets to use font-awesome or some other icon, etc.'),
+                    '#default_value' => AdvancedSearchForm::getAddOperator(),
+                ],
+                self::SEARCH_REMOVE_OPERATOR => [
+                    '#type' => 'textfield',
+                    '#title' => $this->t('Facet Remove Operator'),
+                    '#description' => $this->t('Users can customize the operator for removing facets to use font-awesome or some other icon, etc.'),
+                    '#default_value' => AdvancedSearchForm::getRemoveOperator(),
+                ],
+            ],
+            'facets' => [
+                '#type' => 'fieldset',
+                '#title' => $this->t('Facets'),
+                self::FACET_TRUNCATE => [
+                    '#type' => 'number',
+                    '#title' => $this->t('Truncate Facet'),
+                    '#description' => $this->t('Optionally truncate the length of facets titles in the display. If unspecified they will not be truncated.'),
+                    '#default_value' => self::getConfig(self::FACET_TRUNCATE, 32),
+                    '#min' => 1,
+                ],
+            ],
+        ];
 
-    $form['display-mode'][self::DISPLAY_GRID_FLAG] = [
-      '#type' => 'checkbox',
-      '#title' => $this
-        ->t('Expose "Grid view" option.'),
-      '#default_value' => self::getConfig(self::DISPLAY_GRID_FLAG, 0),
-    ];
+        return parent::buildForm($form, $form_state);
+    }
 
-    $form['display-mode'][self::DISPLAY_DEFAULT] = [
-      '#type' => 'select',
-      '#title' => $this
-        ->t('Default view mode:'),
-      '#options' => [
-        'list' => 'List',
-        'grid' => 'Grid',
-      ],
-      '#default_value' => self::getConfig(self::DISPLAY_DEFAULT, 'grid'),
-    ];
+    /**
+     * {@inheritdoc}
+     */
+    public function submitForm(array &$form, FormStateInterface $form_state) {
+        $config = $this->configFactory->getEditable(self::CONFIG_NAME);
+        $config
+            ->set(self::SEARCH_QUERY_PARAMETER, $form_state->getValue(self::SEARCH_QUERY_PARAMETER))
+            ->set(self::SEARCH_RECURSIVE_PARAMETER, $form_state->getValue(self::SEARCH_RECURSIVE_PARAMETER))
+            ->set(self::SEARCH_ADD_OPERATOR, $form_state->getValue(self::SEARCH_ADD_OPERATOR))
+            ->set(self::SEARCH_REMOVE_OPERATOR, $form_state->getValue(self::SEARCH_REMOVE_OPERATOR))
+            ->set(self::FACET_TRUNCATE, $form_state->getValue(self::FACET_TRUNCATE))
+            ->set(self::EDISMAX_SEARCH_FLAG, $form_state->getValue(self::EDISMAX_SEARCH_FLAG))
+            ->set(self::EDISMAX_SEARCH_LABEL, $form_state->getValue(self::EDISMAX_SEARCH_LABEL))
+            ->set(self::SEARCH_ALL_FIELDS_FLAG, $form_state->getValue(self::SEARCH_ALL_FIELDS_FLAG))
+            ->set(self::DISPLAY_LIST_FLAG, $form_state->getValue(self::DISPLAY_LIST_FLAG))
+            ->set(self::DISPLAY_GRID_FLAG, $form_state->getValue(self::DISPLAY_GRID_FLAG))
+            ->set(self::DISPLAY_DEFAULT, $form_state->getValue(self::DISPLAY_DEFAULT))
+            ->set(self::RECURSIVE_FIELD_FLAG, $form_state->getValue(self::RECURSIVE_FIELD_FLAG))
+            ->save();
+        parent::submitForm($form, $form_state);
+    }
 
-    $form += [
-      'search' => [
-        '#type' => 'fieldset',
-        '#title' => $this->t('Advanced Search'),
-        self::SEARCH_QUERY_PARAMETER => [
-          '#type' => 'textfield',
-          '#title' => $this->t('Search Query Parameter'),
-          '#description' => $this->t('The url parameter in which the advanced search query is stored.'),
-          '#default_value' => AdvancedSearchQuery::getQueryParameter(),
-        ],
-        self::SEARCH_RECURSIVE_PARAMETER => [
-          '#type' => 'textfield',
-          '#title' => $this->t('Recurse Query Parameter'),
-          '#description' => $this->t('The url parameter which can toggle recursive search.'),
-          '#default_value' => AdvancedSearchQuery::getRecurseParameter(),
-        ],
-        self::SEARCH_ADD_OPERATOR => [
-          '#type' => 'textfield',
-          '#title' => $this->t('Facet Add Operator'),
-          '#description' => $this->t('Users can customize the operator for adding facets to use font-awesome or some other icon, etc.'),
-          '#default_value' => AdvancedSearchForm::getAddOperator(),
-        ],
-        self::SEARCH_REMOVE_OPERATOR => [
-          '#type' => 'textfield',
-          '#title' => $this->t('Facet Remove Operator'),
-          '#description' => $this->t('Users can customize the operator for removing facets to use font-awesome or some other icon, etc.'),
-          '#default_value' => AdvancedSearchForm::getRemoveOperator(),
-        ],
-      ],
-      'facets' => [
-        '#type' => 'fieldset',
-        '#title' => $this->t('Facets'),
-        self::FACET_TRUNCATE => [
-          '#type' => 'number',
-          '#title' => $this->t('Truncate Facet'),
-          '#description' => $this->t('Optionally truncate the length of facets titles in the display. If unspecified they will not be truncated.'),
-          '#default_value' => self::getConfig(self::FACET_TRUNCATE, 32),
-          '#min' => 1,
-        ],
-      ],
-    ];
-
-    return parent::buildForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
-    // Filter out unchecked checkboxes (value = '0') from query_fields.
-    $query_fields = $form_state->getValue(self::QUERY_FIELDS);
-    $query_fields = is_array($query_fields) ? array_filter($query_fields) : [];
-
-    $config = $this->configFactory->getEditable(self::CONFIG_NAME);
-    $config
-      ->set(self::SEARCH_QUERY_PARAMETER, $form_state->getValue(self::SEARCH_QUERY_PARAMETER))
-      ->set(self::SEARCH_RECURSIVE_PARAMETER, $form_state->getValue(self::SEARCH_RECURSIVE_PARAMETER))
-      ->set(self::SEARCH_ADD_OPERATOR, $form_state->getValue(self::SEARCH_ADD_OPERATOR))
-      ->set(self::SEARCH_REMOVE_OPERATOR, $form_state->getValue(self::SEARCH_REMOVE_OPERATOR))
-      ->set(self::FACET_TRUNCATE, $form_state->getValue(self::FACET_TRUNCATE))
-      ->set(self::EDISMAX_SEARCH_FLAG, $form_state->getValue(self::EDISMAX_SEARCH_FLAG))
-      ->set(self::EDISMAX_SEARCH_LABEL, $form_state->getValue(self::EDISMAX_SEARCH_LABEL))
-      ->set(self::SEARCH_ALL_FIELDS_FLAG, $form_state->getValue(self::SEARCH_ALL_FIELDS_FLAG))
-      ->set(self::DISPLAY_LIST_FLAG, $form_state->getValue(self::DISPLAY_LIST_FLAG))
-      ->set(self::DISPLAY_GRID_FLAG, $form_state->getValue(self::DISPLAY_GRID_FLAG))
-      ->set(self::DISPLAY_DEFAULT, $form_state->getValue(self::DISPLAY_DEFAULT))
-      ->set(self::QUERY_FIELDS, $query_fields)
-      ->save();
-    parent::submitForm($form, $form_state);
-  }
 }

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -14,75 +14,107 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class SettingsForm extends ConfigFormBase {
 
-    use GetConfigTrait;
+  use GetConfigTrait;
 
-    const CONFIG_NAME = 'advanced_search.settings';
-    const SEARCH_QUERY_PARAMETER = 'search_query_parameter';
-    const SEARCH_RECURSIVE_PARAMETER = 'search_recursive_parameter';
-    const SEARCH_ADD_OPERATOR = 'search_add_operator';
-    const SEARCH_REMOVE_OPERATOR = 'search_remove_operator';
-    const FACET_TRUNCATE = 'facet_truncate';
-    const EDISMAX_SEARCH_FLAG = 'lucene_on_off';
-    const EDISMAX_SEARCH_LABEL = 'lucene_label';
-    const SEARCH_ALL_FIELDS_FLAG = 'all_fields_on_off';
-    const RECURSIVE_FLAG = 'recursive';
-    const DISPLAY_LIST_FLAG = 'list_on_off';
-    const DISPLAY_GRID_FLAG = 'grid_on_off';
-    const DISPLAY_DEFAULT = 'default-display-mode';
+  const CONFIG_NAME = 'advanced_search.settings';
 
-    /**
-     * Constructs a \Drupal\system\ConfigFormBase object.
-     *
-     * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-     *   The factory for configuration objects.
-     */
-    final public function __construct(ConfigFactoryInterface $config_factory) {
-        $this->setConfigFactory($config_factory);
+  const SEARCH_QUERY_PARAMETER = 'search_query_parameter';
+
+  const SEARCH_RECURSIVE_PARAMETER = 'search_recursive_parameter';
+
+  const SEARCH_ADD_OPERATOR = 'search_add_operator';
+
+  const SEARCH_REMOVE_OPERATOR = 'search_remove_operator';
+
+  const FACET_TRUNCATE = 'facet_truncate';
+
+  const EDISMAX_SEARCH_FLAG = 'lucene_on_off';
+
+  const EDISMAX_SEARCH_LABEL = 'lucene_label';
+
+  const SEARCH_ALL_FIELDS_FLAG = 'all_fields_on_off';
+
+  const RECURSIVE_FLAG = 'recursive';
+
+  const DISPLAY_LIST_FLAG = 'list_on_off';
+
+  const DISPLAY_GRID_FLAG = 'grid_on_off';
+
+  const DISPLAY_DEFAULT = 'default-display-mode';
+
+  const QUERY_FIELDS = 'query_fields';
+
+  /**
+   * {@inheritdoc}
+   */
+  final public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->setConfigFactory($config_factory);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static($container->get('config.factory'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'advanced_search_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [self::CONFIG_NAME];
+  }
+
+  /**
+   * Get available fields from all Search API indexes.
+   *
+   * @return array
+   *   Field ID => label.
+   */
+  protected function getAvailableFields(): array {
+    $options = [];
+    $indexes = \Drupal::entityTypeManager()
+      ->getStorage('search_api_index')
+      ->loadMultiple();
+
+    foreach ($indexes as $index) {
+      foreach ($index->getFields() as $id => $field) {
+        $options[$id] = $field->getLabel() . " ($id)";
+      }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public static function create(ContainerInterface $container) {
-        return new static($container->get('config.factory'));
-    }
+    return $options;
+  }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getFormId() {
-        return 'advanced_search_settings_form';
-    }
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    /* -------------------------
+     * Advanced Search (eDisMax)
+     * ------------------------- */
+    $form['eDisMax'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Advanced Search Block'),
+      '#weight' => -1,
+    ];
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getEditableConfigNames() {
-        return [
-            self::CONFIG_NAME,
-        ];
-    }
+    $form['eDisMax']['description'] = [
+      '#markup' => $this->t('Advanced Search Blocks are available in the Blocks interface for each Search API view. These settings apply globally.'),
+    ];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(array $form, FormStateInterface $form_state) {
-        $form['eDisMax'] = [
-            '#type' => 'fieldset',
-            '#title' => $this->t('Advanced Search Block'),
-            '#weight' => -1,
-        ];
-        $form['eDisMax']['advanced-search-block-description'] = [
-            '#markup' => $this->t("Advanced Search Blocks are available in the Blocks interface for each Search API view. When placing an Advanced Search Block, you can configure the fields that are used for field-based search and whether a “recursive” search is available.  The following settings apply to all Advanced Search blocks."),
-            '#weight' => -2,
-        ];
-
-        $isEDismax = \Drupal::config(SettingsForm::CONFIG_NAME)->get(self::EDISMAX_SEARCH_FLAG);
-        $form['eDisMax'][self::EDISMAX_SEARCH_FLAG] = [
-            '#type' => 'checkbox',
-            '#title' => $this
-                ->t('Enable Extended DisMax Query.'),
-            '#description' => $this->t('<ul> <li>When enabled, all queries using an Advanced Search Block use the Extended Dismax (eDisMax) query processor.</li>
+    $form['eDisMax'][self::EDISMAX_SEARCH_FLAG] = [
+      '#type' => 'checkbox',
+      '#title' => $this
+        ->t('Enable Extended DisMax Query.'),
+      '#description' => $this->t('<ul> <li>When enabled, all queries using an Advanced Search Block use the Extended Dismax (eDisMax) query processor.</li>
         <li>This setting must be enabled for the “Simple Search Block” to function. </li>
         <li>If enabled, the “Simple Search Block”/”Advanced Search Blocks” support:
            <ul>
@@ -92,142 +124,159 @@ class SettingsForm extends ConfigFormBase {
            </ul>
           </li>
         </ul>'),
-            '#default_value' => $isEDismax ?? 1,
-        ];
+      '#default_value' => $isEDismax ?? 1,
+    ];
 
-        $form['eDisMax']['textfields_container'] = [
-            '#type' => 'container',
-            '#attributes' => ['id' => 'edismax-container'],
-        ];
+    $form['eDisMax']['container'] = [
+      '#type' => 'container',
+    ];
 
-        $form['eDisMax']['textfields_container'][self::SEARCH_ALL_FIELDS_FLAG] = [
-            '#type' => 'checkbox',
-            '#title' => $this
-                ->t('Enable searching all fields'),
-            '#description' => $this->t('<ul>
+    $form['eDisMax']['textfields_container'][self::SEARCH_ALL_FIELDS_FLAG] = [
+      '#type' => 'checkbox',
+      '#title' => $this
+        ->t('Enable searching all fields'),
+      '#description' => $this->t('<ul>
           <li>This makes an additional option visible in all Advanced Search Blocks, which searches across all fields. Its label is configured below.</li>
-          <li>This setting must be enabled for the “Simple Search Block” to function.</li>
+          <li>This setting must be enabled for the "Simple Search Block" to function.</li>
         </ul>'),
-            '#default_value' => self::getConfig(self::SEARCH_ALL_FIELDS_FLAG, 0),
-        ];
+      '#default_value' => self::getConfig(self::SEARCH_ALL_FIELDS_FLAG, 0),
+    ];
 
-        $form['eDisMax']['textfields_container'][self::RECURSIVE_FLAG] = [
-            '#type' => 'checkbox',
-            '#title' => $this
-                ->t('Search collections recursively by default.'),
-            '#description' => $this->t('<ul>
-          <li>Select whether subcollections are searched by default.</li>
-          <li>The user can override this setting.</li>
-        </ul>'),
-            '#default_value' => self::getConfig(self::RECURSIVE_FLAG, 0),
-        ];
-        $form['eDisMax']['textfields_container'][self::EDISMAX_SEARCH_LABEL] = [
-            '#type' => 'textfield',
-            '#title' => $this->t('If enabled, set the label for the option of searching all fields'),
-            '#description' => $this->t('E.g. keyword.'),
-            '#default_value' => self::getConfig(self::EDISMAX_SEARCH_LABEL, "Keyword"),
-        ];
+    $form['eDisMax']['textfields_container'][self::RECURSIVE_FLAG] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Search collections recursively by default.'),
+      '#description' => $this->t('<ul> <li>Select whether subcollections are searched by default.</li> <li>The user can override this setting.</li> </ul>'),
+      '#default_value' => self::getConfig(self::RECURSIVE_FLAG, 0),
+    ];
 
+    $form['eDisMax']['container'][self::EDISMAX_SEARCH_LABEL] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('All fields label'),
+      '#default_value' => self::getConfig(self::EDISMAX_SEARCH_LABEL, 'Keyword'),
+    ];
 
+    /* -------------------------
+     * Query Fields
+     * ------------------------- */
+    $form['query_fields_block'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Query Fields'),
+    ];
 
-        $form['display-mode'] = [
-            '#type' => 'fieldset',
-            '#title' => $this->t("Pager Block"),
-        ];
-        $form['display-mode']['pager-block-description'] = [
-            '#markup' => $this->t("Pager blocks are available in the Blocks interface for each Search API view.  The following settings apply for all Pager blocks."),
-        ];
+    $base_url = \Drupal::request()->getSchemeAndHttpHost();
+    $form['query_fields_block']['description'] = [
+      '#markup' => $this->t(
+        'Select fields to query when using the all-fields option. If none are selected, <a href="@url" target="_blank">all fields will be searched</a>.',
+        ['@url' => $base_url . '/admin/config/search/search-api']
+      ),
+    ];
 
-        $form['display-mode'][self::DISPLAY_LIST_FLAG] = [
-            '#type' => 'checkbox',
-            '#title' => $this
-                ->t('Expose "List view" option.'),
-            '#default_value' => self::getConfig(self::DISPLAY_LIST_FLAG, 0),
-        ];
+    $form['query_fields_block'][self::QUERY_FIELDS] = [
+      '#type' => 'checkboxes',
+      '#options' => $this->getAvailableFields(),
+      '#default_value' => self::getConfig(self::QUERY_FIELDS, []),
+    ];
 
-        $form['display-mode'][self::DISPLAY_GRID_FLAG] = [
-            '#type' => 'checkbox',
-            '#title' => $this
-                ->t('Expose "Grid view" option.'),
-            '#default_value' => self::getConfig(self::DISPLAY_GRID_FLAG, 0),
-        ];
+    /* -------------------------
+     * Pager Block
+     * ------------------------- */
+    $form['display'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Pager Block'),
+    ];
 
-        $form['display-mode'][self::DISPLAY_DEFAULT] = [
-            '#type' => 'select',
-            '#title' => $this
-                ->t('Default view mode:'),
-            '#options' => [
-                'list' => 'List',
-                'grid' => 'Grid',
-            ],
-            '#default_value' => self::getConfig(self::DISPLAY_DEFAULT, 'grid'),
-        ];
+    $form['display'][self::DISPLAY_LIST_FLAG] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Expose list view'),
+      '#default_value' => self::getConfig(self::DISPLAY_LIST_FLAG, 0),
+    ];
 
-        $form += [
-            'search' => [
-                '#type' => 'fieldset',
-                '#title' => $this->t('Advanced Search'),
-                self::SEARCH_QUERY_PARAMETER => [
-                    '#type' => 'textfield',
-                    '#title' => $this->t('Search Query Parameter'),
-                    '#description' => $this->t('The url parameter in which the advanced search query is stored.'),
-                    '#default_value' => AdvancedSearchQuery::getQueryParameter(),
-                ],
-                self::SEARCH_RECURSIVE_PARAMETER => [
-                    '#type' => 'textfield',
-                    '#title' => $this->t('Recurse Query Parameter'),
-                    '#description' => $this->t('The url parameter which can toggle recursive search.'),
-                    '#default_value' => AdvancedSearchQuery::getRecurseParameter(),
-                ],
-                self::SEARCH_ADD_OPERATOR => [
-                    '#type' => 'textfield',
-                    '#title' => $this->t('Facet Add Operator'),
-                    '#description' => $this->t('Users can customize the operator for adding facets to use font-awesome or some other icon, etc.'),
-                    '#default_value' => AdvancedSearchForm::getAddOperator(),
-                ],
-                self::SEARCH_REMOVE_OPERATOR => [
-                    '#type' => 'textfield',
-                    '#title' => $this->t('Facet Remove Operator'),
-                    '#description' => $this->t('Users can customize the operator for removing facets to use font-awesome or some other icon, etc.'),
-                    '#default_value' => AdvancedSearchForm::getRemoveOperator(),
-                ],
-            ],
-            'facets' => [
-                '#type' => 'fieldset',
-                '#title' => $this->t('Facets'),
-                self::FACET_TRUNCATE => [
-                    '#type' => 'number',
-                    '#title' => $this->t('Truncate Facet'),
-                    '#description' => $this->t('Optionally truncate the length of facets titles in the display. If unspecified they will not be truncated.'),
-                    '#default_value' => self::getConfig(self::FACET_TRUNCATE, 32),
-                    '#min' => 1,
-                ],
-            ],
-        ];
+    $form['display'][self::DISPLAY_GRID_FLAG] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Expose grid view'),
+      '#default_value' => self::getConfig(self::DISPLAY_GRID_FLAG, 0),
+    ];
 
-        return parent::buildForm($form, $form_state);
-    }
+    $form['display'][self::DISPLAY_DEFAULT] = [
+      '#type' => 'select',
+      '#title' => $this->t('Default display mode'),
+      '#options' => ['list' => 'List', 'grid' => 'Grid'],
+      '#default_value' => self::getConfig(self::DISPLAY_DEFAULT, 'grid'),
+    ];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function submitForm(array &$form, FormStateInterface $form_state) {
-        $config = $this->configFactory->getEditable(self::CONFIG_NAME);
-        $config
-            ->set(self::SEARCH_QUERY_PARAMETER, $form_state->getValue(self::SEARCH_QUERY_PARAMETER))
-            ->set(self::SEARCH_RECURSIVE_PARAMETER, $form_state->getValue(self::SEARCH_RECURSIVE_PARAMETER))
-            ->set(self::SEARCH_ADD_OPERATOR, $form_state->getValue(self::SEARCH_ADD_OPERATOR))
-            ->set(self::SEARCH_REMOVE_OPERATOR, $form_state->getValue(self::SEARCH_REMOVE_OPERATOR))
-            ->set(self::FACET_TRUNCATE, $form_state->getValue(self::FACET_TRUNCATE))
-            ->set(self::EDISMAX_SEARCH_FLAG, $form_state->getValue(self::EDISMAX_SEARCH_FLAG))
-            ->set(self::EDISMAX_SEARCH_LABEL, $form_state->getValue(self::EDISMAX_SEARCH_LABEL))
-            ->set(self::SEARCH_ALL_FIELDS_FLAG, $form_state->getValue(self::SEARCH_ALL_FIELDS_FLAG))
-            ->set(self::DISPLAY_LIST_FLAG, $form_state->getValue(self::DISPLAY_LIST_FLAG))
-            ->set(self::DISPLAY_GRID_FLAG, $form_state->getValue(self::DISPLAY_GRID_FLAG))
-            ->set(self::DISPLAY_DEFAULT, $form_state->getValue(self::DISPLAY_DEFAULT))
-            ->set(self::RECURSIVE_FLAG, $form_state->getValue(self::RECURSIVE_FLAG))
-            ->save();
-        parent::submitForm($form, $form_state);
-    }
+    /* -------------------------
+     * Advanced Search Params
+     * ------------------------- */
+    $form['search'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Advanced Search'),
+    ];
+
+    $form['search'][self::SEARCH_QUERY_PARAMETER] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search Query Parameter'),
+      '#default_value' => AdvancedSearchQuery::getQueryParameter(),
+    ];
+
+    $form['search'][self::SEARCH_RECURSIVE_PARAMETER] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Recursive Query Parameter'),
+      '#default_value' => AdvancedSearchQuery::getRecurseParameter(),
+    ];
+
+    $form['search'][self::SEARCH_ADD_OPERATOR] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Facet Add Operator'),
+      '#default_value' => AdvancedSearchForm::getAddOperator(),
+    ];
+
+    $form['search'][self::SEARCH_REMOVE_OPERATOR] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Facet Remove Operator'),
+      '#default_value' => AdvancedSearchForm::getRemoveOperator(),
+    ];
+
+    /* -------------------------
+     * Facets
+     * ------------------------- */
+    $form['facets'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Facets'),
+    ];
+
+    $form['facets'][self::FACET_TRUNCATE] = [
+      '#type' => 'number',
+      '#title' => $this->t('Truncate facet labels'),
+      '#default_value' => self::getConfig(self::FACET_TRUNCATE, 32),
+      '#min' => 1,
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $query_fields = array_filter((array) $form_state->getValue(self::QUERY_FIELDS));
+
+    $this->configFactory->getEditable(self::CONFIG_NAME)
+      ->set(self::SEARCH_QUERY_PARAMETER, $form_state->getValue(self::SEARCH_QUERY_PARAMETER))
+      ->set(self::SEARCH_RECURSIVE_PARAMETER, $form_state->getValue(self::SEARCH_RECURSIVE_PARAMETER))
+      ->set(self::SEARCH_ADD_OPERATOR, $form_state->getValue(self::SEARCH_ADD_OPERATOR))
+      ->set(self::SEARCH_REMOVE_OPERATOR, $form_state->getValue(self::SEARCH_REMOVE_OPERATOR))
+      ->set(self::FACET_TRUNCATE, $form_state->getValue(self::FACET_TRUNCATE))
+      ->set(self::EDISMAX_SEARCH_FLAG, $form_state->getValue(self::EDISMAX_SEARCH_FLAG))
+      ->set(self::EDISMAX_SEARCH_LABEL, $form_state->getValue(self::EDISMAX_SEARCH_LABEL))
+      ->set(self::SEARCH_ALL_FIELDS_FLAG, $form_state->getValue(self::SEARCH_ALL_FIELDS_FLAG))
+      ->set(self::RECURSIVE_FLAG, $form_state->getValue(self::RECURSIVE_FLAG))
+      ->set(self::DISPLAY_LIST_FLAG, $form_state->getValue(self::DISPLAY_LIST_FLAG))
+      ->set(self::DISPLAY_GRID_FLAG, $form_state->getValue(self::DISPLAY_GRID_FLAG))
+      ->set(self::DISPLAY_DEFAULT, $form_state->getValue(self::DISPLAY_DEFAULT))
+      ->set(self::QUERY_FIELDS, $query_fields)
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
 
 }

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -25,7 +25,7 @@ class SettingsForm extends ConfigFormBase {
     const EDISMAX_SEARCH_FLAG = 'lucene_on_off';
     const EDISMAX_SEARCH_LABEL = 'lucene_label';
     const SEARCH_ALL_FIELDS_FLAG = 'all_fields_on_off';
-    const RECURSIVE_FIELD_FLAG = 'recursive';
+    const RECURSIVE_FLAG = 'recursive';
     const DISPLAY_LIST_FLAG = 'list_on_off';
     const DISPLAY_GRID_FLAG = 'grid_on_off';
     const DISPLAY_DEFAULT = 'default-display-mode';
@@ -111,7 +111,7 @@ class SettingsForm extends ConfigFormBase {
             '#default_value' => self::getConfig(self::SEARCH_ALL_FIELDS_FLAG, 0),
         ];
 
-        $form['eDisMax']['textfields_container'][self::RECURSIVE_FIELD_FLAG] = [
+        $form['eDisMax']['textfields_container'][self::RECURSIVE_FLAG] = [
             '#type' => 'checkbox',
             '#title' => $this
                 ->t('Search collections recursively by default.'),
@@ -119,7 +119,7 @@ class SettingsForm extends ConfigFormBase {
           <li>Select whether subcollections are searched by default.</li>
           <li>The user can override this setting.</li>
         </ul>'),
-            '#default_value' => self::getConfig(self::RECURSIVE_FIELD_FLAG, 0),
+            '#default_value' => self::getConfig(self::RECURSIVE_FLAG, 0),
         ];
         $form['eDisMax']['textfields_container'][self::EDISMAX_SEARCH_LABEL] = [
             '#type' => 'textfield',
@@ -225,7 +225,7 @@ class SettingsForm extends ConfigFormBase {
             ->set(self::DISPLAY_LIST_FLAG, $form_state->getValue(self::DISPLAY_LIST_FLAG))
             ->set(self::DISPLAY_GRID_FLAG, $form_state->getValue(self::DISPLAY_GRID_FLAG))
             ->set(self::DISPLAY_DEFAULT, $form_state->getValue(self::DISPLAY_DEFAULT))
-            ->set(self::RECURSIVE_FIELD_FLAG, $form_state->getValue(self::RECURSIVE_FIELD_FLAG))
+            ->set(self::RECURSIVE_FLAG, $form_state->getValue(self::RECURSIVE_FLAG))
             ->save();
         parent::submitForm($form, $form_state);
     }

--- a/src/Plugin/Block/SearchResultsPagerBlock.php
+++ b/src/Plugin/Block/SearchResultsPagerBlock.php
@@ -25,397 +25,389 @@ use Drupal\Core\Form\FormStateInterface;
  *  category = @Translation("Islandora"),
  * )
  */
-class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPluginInterface
-{
-    use ViewAndDisplayIdentifiersTrait;
+class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPluginInterface {
+  use ViewAndDisplayIdentifiersTrait;
 
-    /**
-     * The clone of the current request object.
-     *
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
-    protected $request;
+  /**
+   * The clone of the current request object.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
 
-    /**
-     * Construct a FacetBlock instance.
-     *
-     * @param array $configuration
-     *   A configuration array containing information about the plugin instance.
-     * @param string $plugin_id
-     *   The plugin_id for the plugin instance.
-     * @param string $plugin_definition
-     *   The plugin implementation definition.
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     *   A request object for the current request.
-     */
-    final public function __construct(array $configuration, $plugin_id, $plugin_definition, Request $request)
-    {
-        parent::__construct($configuration, $plugin_id, $plugin_definition);
-        $this->request = clone $request;
-    }
+  /**
+   * Construct a FacetBlock instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param string $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   A request object for the current request.
+   */
+  final public function __construct(array $configuration, $plugin_id, $plugin_definition, Request $request) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->request = clone $request;
+  }
 
-    /**
-     * {@inheritdoc}
-     */
-    public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition)
-    {
-        return new static(
-            $configuration,
-            $plugin_id,
-            $plugin_definition,
-            $container->get('request_stack')->getMainRequest()
-        );
-    }
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('request_stack')->getMainRequest()
+    );
+  }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function blockForm($form, FormStateInterface $form_state)
-    {
-        $config = \Drupal::config(SettingsForm::CONFIG_NAME);
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $config = \Drupal::config(SettingsForm::CONFIG_NAME);
 
-        $form['display-mode'] = [
-            '#type' => 'fieldset',
-            '#title' => $this->t("Pager Block"),
-            '#description' => $this->t("If this settings are set here, they will override the global settings at `/admin/config/search/advanced`")
-        ];
+    $form['display-mode'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t("Pager Block"),
+      '#description' => $this->t("If this settings are set here, they will override the global settings at `/admin/config/search/advanced`")
+    ];
+    
+    $form['display-mode']['override_list_on_off'] = [
+      '#type' => 'checkbox',
+      '#title' => $this
+        ->t('Expose "List view" option.'),
+      '#default_value' => $this->configuration['override_list_on_off'] ?? $config->get(SettingsForm::DISPLAY_LIST_FLAG),
+    ];
 
-        $form['display-mode']['override_list_on_off'] = [
-            '#type' => 'checkbox',
-            '#title' => $this
-                ->t('Expose "List view" option.'),
-            '#default_value' => $this->configuration['override_list_on_off'] ?? $config->get(SettingsForm::DISPLAY_LIST_FLAG),
-        ];
+    $form['display-mode']['override_grid_on_off'] = [
+      '#type' => 'checkbox',
+      '#title' => $this
+        ->t('Expose "Grid view" option.'),
+      '#default_value' => $this->configuration['override_grid_on_off'] ?? $config->get(SettingsForm::DISPLAY_GRID_FLAG),
+    ];
 
-        $form['display-mode']['override_grid_on_off'] = [
-            '#type' => 'checkbox',
-            '#title' => $this
-                ->t('Expose "Grid view" option.'),
-            '#default_value' => $this->configuration['override_grid_on_off'] ?? $config->get(SettingsForm::DISPLAY_GRID_FLAG),
-        ];
+    $form['display-mode']['override-default-display-mode'] = [
+      '#type' => 'select',
+      '#title' => $this
+        ->t('Default view mode:'),
+      '#options' => [
+        'list' => 'List',
+        'grid' => 'Grid',
+      ],
+      '#default_value' => $this->configuration['override-default-display-mode'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT),
+    ];
+    
+    $form['#attributes']['class'][] = 'clearfix';
+    $form['#attached']['library'][] = 'advanced_search/advanced.search.admin';
+    return $form; 
+  }
 
-        $form['display-mode']['override-default-display-mode'] = [
-            '#type' => 'select',
-            '#title' => $this
-                ->t('Default view mode:'),
-            '#options' => [
-                'list' => 'List',
-                'grid' => 'Grid',
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $values = $form_state->getValues();
+    $this->configuration["override_list_on_off"] = $values["display-mode"]['override_list_on_off'];
+    $this->configuration["override_grid_on_off"] = $values["display-mode"]['override_grid_on_off'];
+    $this->configuration["override-default-display-mode"] = $values["display-mode"]['override-default-display-mode'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $id = $this->getDerivativeId();
+    [$view_id, $display_id] = $this->getViewAndDisplayIdentifiers();
+    $view = View::Load($view_id);
+    $view_executable = $view->getExecutable();
+    $view_executable->setDisplay($display_id);
+    // Allow advanced search to alter the query.
+    $advanced_search_query = new AdvancedSearchQuery();
+    $advanced_search_query->alterView($this->request, $view_executable, $display_id);
+    $view_executable->execute();
+    $pager = $view_executable->getPager();
+    $exposed_input = $view_executable->getExposedInput();
+    $query_parameters = $this->request->query->all();
+    $build = [
+      '#attached' => [
+        'drupalSettings' => [
+          'advanced_search_pager_views_ajax' => [
+            $id => [
+              'view_id' => $view_id,
+              'current_display_id' => $display_id,
+              'ajax_path' => '/views/ajax',
             ],
-            '#default_value' => $this->configuration['override-default-display-mode'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT),
+          ],
+        ],
+      ],
+      '#attributes' => [
+        'class' => ['advanced_search_result_pager'],
+        'data-drupal-pager-id' => $id,
+      ],
+      'result_summary' => $this->buildResultsSummary($view_executable),
+      'container' => [
+        '#prefix' => '<div class="pager__group">',
+        '#suffix' => '</div>',
+        'results_per_page_links' => $this->buildResultsPerPageLinks($pager, $query_parameters),
+        'display_links' => $this->buildDisplayLinks($query_parameters),
+        'sort_by' => $this->buildSortByForm($view_executable->sort, $query_parameters),
+        'pager' => array_merge($pager->render($exposed_input), ['#wrapper_attributes' => ['class' => ['container']]]),
+      ],
+    ];
+    return $build;
+  }
+
+  /**
+   * Build the results summary portion of the pager.
+   *
+   * @param Drupal\views\ViewExecutable $view_executable
+   *   The view to build the summary for.
+   *
+   * @return array
+   *   A renderable array that represents the current page, and number of
+   *   results in the view.
+   */
+  protected function buildResultsSummary(ViewExecutable $view_executable) {
+    $current_page = (int) $view_executable->getCurrentPage() + 1;
+    $per_page = (int) $view_executable->getItemsPerPage();
+    $total = $view_executable->total_rows ?? count($view_executable->result);
+    // If there is no result the "start" and "current_record_count" should be
+    // equal to 0. To have the same calculation logic, we use a "start offset"
+    // to handle all the cases.
+    $start_offset = empty($total) ? 0 : 1;
+    if ($per_page === 0) {
+      $start = $start_offset;
+      $end = $total;
+    }
+    else {
+      $total_count = $current_page * $per_page;
+      if ($total_count > $total) {
+        $total_count = $total;
+      }
+      $start = ($current_page - 1) * $per_page + $start_offset;
+      $end = $total_count;
+    }
+    if (!empty($total)) {
+      // Return as render array.
+      return [
+        '#prefix' => '<div class="pager__summary">',
+        '#suffix' => '</div>',
+        '#markup' => $this->t('Displaying @start - @end of @total', [
+          '@start' => $start,
+          '@end' => $end,
+          '@total' => $total,
+        ]),
+      ];
+    }
+    return [];
+  }
+
+  /**
+   * Build the results per page portion of the pager.
+   *
+   * @param Drupal\views\Plugin\views\pager\SqlBase $pager
+   *   The pager for the view.
+   * @param array $query_parameters
+   *   The query parameters used to change the number of results per page.
+   *
+   * @return array
+   *   A renderable array representing the results per page portion of pager.
+   */
+  protected function buildResultsPerPageLinks(SqlBase $pager, array $query_parameters) {
+    $active_items_per_page = $query_parameters['items_per_page'] ?? $pager->options['items_per_page'];
+    $items_per_page_options = array_map(function ($value) {
+      return trim($value);
+    }, explode(',', $pager->options['expose']['items_per_page_options']));
+    $items = [];
+    foreach ($items_per_page_options as $items_per_page) {
+      $url = Url::fromRoute('<current>', [], [
+        // When changing the number of items displayed always return the user
+        // to the first page.
+        'query' => array_merge($query_parameters, [
+          'items_per_page' => $items_per_page,
+          'page' => 0,
+        ]),
+        'absolute' => TRUE,
+      ]);
+      $active = $items_per_page == $active_items_per_page;
+      $items[] = [
+        '#type' => 'link',
+        '#url' => $url,
+        '#title' => $items_per_page,
+        '#attributes' => [
+          'aria-label' => $this->t("@item items per page", ["@item" => $items_per_page]),
+          'class' => $active ?
+            ['pager__link', 'pager__link--is-active', 'pager__itemsperpage'] :
+            ['pager__link', 'pager__itemsperpage'],
+        ],
+        '#wrapper_attributes' => [
+          'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],
+        ],
+      ];
+    }
+    return [
+      '#theme' => 'item_list',
+      '#title' => $this->t('Results per page'),
+      '#list_type' => 'ul',
+      '#items' => $items,
+      '#attributes' => [],
+      '#wrapper_attributes' => ['class' => ['pager__results', 'container']],
+    ];
+  }
+
+  /**
+   * Build the display links portion of the pager (list/grid).
+   *
+   * @param array $query_parameters
+   *   The query parameters used to change the display format.
+   *
+   * @return array
+   *   A renderable array representing the display links portion of pager.
+   */
+  protected function buildDisplayLinks(array $query_parameters) {
+    $config = \Drupal::config(SettingsForm::CONFIG_NAME);
+    $display_options = [];
+
+
+    if (isset($this->configuration["override_list_on_off"]) && isset($this->configuration["override_grid_on_off"])
+    && isset($this->configuration["override-default-display-mode"])) {
+      if ($this->configuration["override_list_on_off"] == 1) { 
+        $display_options['list'] = [
+          'icon' => 'fa-list',
+          'title' => $this->t('List'),
         ];
+      } 
 
-        $form['#attributes']['class'][] = 'clearfix';
-        $form['#attached']['library'][] = 'advanced_search/advanced.search.admin';
-        return $form;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function blockSubmit($form, FormStateInterface $form_state)
-    {
-        $values = $form_state->getValues();
-        $this->configuration["override_list_on_off"] = $values["display-mode"]['override_list_on_off'];
-        $this->configuration["override_grid_on_off"] = $values["display-mode"]['override_grid_on_off'];
-        $this->configuration["override-default-display-mode"] = $values["display-mode"]['override-default-display-mode'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function build()
-    {
-        $id = $this->getDerivativeId();
-        [$view_id, $display_id] = $this->getViewAndDisplayIdentifiers();
-        $view = View::Load($view_id);
-        $view_executable = $view->getExecutable();
-        $view_executable->setDisplay($display_id);
-        // Allow advanced search to alter the query.
-        $advanced_search_query = new AdvancedSearchQuery();
-        $advanced_search_query->alterView($this->request, $view_executable, $display_id);
-        $view_executable->execute();
-        $pager = $view_executable->getPager();
-        $exposed_input = $view_executable->getExposedInput();
-        $query_parameters = $this->request->query->all();
-        $build = [
-            '#attached' => [
-                'drupalSettings' => [
-                    'advanced_search_pager_views_ajax' => [
-                        $id => [
-                            'view_id' => $view_id,
-                            'current_display_id' => $display_id,
-                            'ajax_path' => '/views/ajax',
-                        ],
-                    ],
-                ],
-            ],
-            '#attributes' => [
-                'class' => ['advanced_search_result_pager'],
-                'data-drupal-pager-id' => $id,
-            ],
-            'result_summary' => $this->buildResultsSummary($view_executable),
-            'container' => [
-                '#prefix' => '<div class="pager__group">',
-                '#suffix' => '</div>',
-                'results_per_page_links' => $this->buildResultsPerPageLinks($pager, $query_parameters),
-                'display_links' => $this->buildDisplayLinks($query_parameters),
-                'sort_by' => $this->buildSortByForm($view_executable->sort, $query_parameters),
-                'pager' => array_merge($pager->render($exposed_input), ['#wrapper_attributes' => ['class' => ['container']]]),
-            ],
+      if ($this->configuration["override_grid_on_off"] == 1) { 
+        $display_options['grid'] = [
+          'icon' => 'fa-th',
+          'title' => $this->t('Grid'),
         ];
-        return $build;
+      }
+      $active_display = $query_parameters['display'] ?? $this->configuration["override-default-display-mode"];
     }
-
-    /**
-     * Build the results summary portion of the pager.
-     *
-     * @param Drupal\views\ViewExecutable $view_executable
-     *   The view to build the summary for.
-     *
-     * @return array
-     *   A renderable array that represents the current page, and number of
-     *   results in the view.
-     */
-    protected function buildResultsSummary(ViewExecutable $view_executable)
-    {
-        $current_page = (int)$view_executable->getCurrentPage() + 1;
-        $per_page = (int)$view_executable->getItemsPerPage();
-        $total = $view_executable->total_rows ?? count($view_executable->result);
-        // If there is no result the "start" and "current_record_count" should be
-        // equal to 0. To have the same calculation logic, we use a "start offset"
-        // to handle all the cases.
-        $start_offset = empty($total) ? 0 : 1;
-        if ($per_page === 0) {
-            $start = $start_offset;
-            $end = $total;
-        } else {
-            $total_count = $current_page * $per_page;
-            if ($total_count > $total) {
-                $total_count = $total;
-            }
-            $start = ($current_page - 1) * $per_page + $start_offset;
-            $end = $total_count;
-        }
-        if (!empty($total)) {
-            // Return as render array.
-            return [
-                '#prefix' => '<div class="pager__summary">',
-                '#suffix' => '</div>',
-                '#markup' => $this->t('Displaying @start - @end of @total', [
-                    '@start' => $start,
-                    '@end' => $end,
-                    '@total' => $total,
-                ]),
-            ];
-        }
-        return [];
-    }
-
-    /**
-     * Build the results per page portion of the pager.
-     *
-     * @param Drupal\views\Plugin\views\pager\SqlBase $pager
-     *   The pager for the view.
-     * @param array $query_parameters
-     *   The query parameters used to change the number of results per page.
-     *
-     * @return array
-     *   A renderable array representing the results per page portion of pager.
-     */
-    protected function buildResultsPerPageLinks(SqlBase $pager, array $query_parameters)
-    {
-        $active_items_per_page = $query_parameters['items_per_page'] ?? $pager->options['items_per_page'];
-        $items_per_page_options = array_map(function ($value) {
-            return trim($value);
-        }, explode(',', $pager->options['expose']['items_per_page_options']));
-        $items = [];
-        foreach ($items_per_page_options as $items_per_page) {
-            $url = Url::fromRoute('<current>', [], [
-                // When changing the number of items displayed always return the user
-                // to the first page.
-                'query' => array_merge($query_parameters, [
-                    'items_per_page' => $items_per_page,
-                    'page' => 0,
-                ]),
-                'absolute' => TRUE,
-            ]);
-            $active = $items_per_page == $active_items_per_page;
-            $items[] = [
-                '#type' => 'link',
-                '#url' => $url,
-                '#title' => $items_per_page,
-                '#attributes' => [
-                    'aria-label' => $this->t("@item items per page", ["@item" => $items_per_page]),
-                    'class' => $active ?
-                        ['pager__link', 'pager__link--is-active', 'pager__itemsperpage'] :
-                        ['pager__link', 'pager__itemsperpage'],
-                ],
-                '#wrapper_attributes' => [
-                    'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],
-                ],
-            ];
-        }
-        return [
-            '#theme' => 'item_list',
-            '#title' => $this->t('Results per page'),
-            '#list_type' => 'ul',
-            '#items' => $items,
-            '#attributes' => [],
-            '#wrapper_attributes' => ['class' => ['pager__results', 'container']],
+    else {
+      if ($config->get(SettingsForm::DISPLAY_LIST_FLAG) == 1) {
+        $display_options['list'] = [
+          'icon' => 'fa-list',
+          'title' => $this->t('List'),
         ];
-    }
+      }
 
-    /**
-     * Build the display links portion of the pager (list/grid).
-     *
-     * @param array $query_parameters
-     *   The query parameters used to change the display format.
-     *
-     * @return array
-     *   A renderable array representing the display links portion of pager.
-     */
-    protected function buildDisplayLinks(array $query_parameters)
-    {
-        $config = \Drupal::config(SettingsForm::CONFIG_NAME);
-        $display_options = [];
-
-
-        if (isset($this->configuration["override_list_on_off"]) && isset($this->configuration["override_grid_on_off"])
-            && isset($this->configuration["override-default-display-mode"])) {
-            if ($this->configuration["override_list_on_off"] == 1) {
-                $display_options['list'] = [
-                    'icon' => 'fa-list',
-                    'title' => $this->t('List'),
-                ];
-            }
-
-            if ($this->configuration["override_grid_on_off"] == 1) {
-                $display_options['grid'] = [
-                    'icon' => 'fa-th',
-                    'title' => $this->t('Grid'),
-                ];
-            }
-            $active_display = $query_parameters['display'] ?? $this->configuration["override-default-display-mode"];
-        } else {
-            if ($config->get(SettingsForm::DISPLAY_LIST_FLAG) == 1) {
-                $display_options['list'] = [
-                    'icon' => 'fa-list',
-                    'title' => $this->t('List'),
-                ];
-            }
-
-            if ($config->get(SettingsForm::DISPLAY_GRID_FLAG) == 1) {
-                $display_options['grid'] = [
-                    'icon' => 'fa-th',
-                    'title' => $this->t('Grid'),
-                ];
-            }
-            $active_display = $query_parameters['display'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT);
-        }
-
-        $items = [];
-        foreach ($display_options as $display => $options) {
-            $url = Url::fromRoute('<current>', [], [
-                'query' => array_merge($query_parameters, ['display' => $display]),
-                'absolute' => TRUE,
-            ]);
-            $text = "<i class='fa {$options['icon']}' aria-hidden='true'>&nbsp;</i><span class='display-mode'>{$options['title']}</span>";
-            $active = $active_display == $display;
-            $items[] = [
-                '#type' => 'link',
-                '#url' => $url,
-                '#title' => Markup::create($text),
-                '#attributes' => [
-                    'class' => $active ?
-                        ['pager__link', 'pager__link--is-active', 'pager__display'] :
-                        ['pager__link', 'pager__display'],
-                    'aria-label' => $this->t("Display as @link", ["@link" => Markup::create($text)]),
-                    'type' => $display
-                ],
-                '#wrapper_attributes' => [
-                    'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],
-                ],
-            ];
-        }
-
-        if (count($items) > 0) {
-            return [
-                '#theme' => 'item_list',
-                '#list_type' => 'ul',
-                '#items' => $items,
-                '#attributes' => [],
-                '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
-            ];
-        } else {
-            return [
-                '#markup' => Markup::create('<span hidden id="override-default-display-mode">' . $active_display . '</span>'),
-                '#attributes' => [],
-                '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
-            ];
-        }
-    }
-
-    /**
-     * Build the sort by portion of the pager.
-     *
-     * @param array $sort_criteria
-     *   The search fields which can be sorted.
-     * @param array $query_parameters
-     *   The query parameters used to change the display format.
-     *
-     * @return array
-     *   A renderable array representing the sort by portion of pager.
-     */
-    protected function buildSortByForm(array $sort_criteria, array $query_parameters)
-    {
-        $default_order = $query_parameters['sort_order'] ?? 'DESC';
-        $default_sort_by = $query_parameters['sort_by'] ?? 'search_api_relevance';
-        $default_value = $default_sort_by . '_' . strtolower($default_order);
-        $options = [];
-        $options_attributes = [];
-        // Not sure if this will work without defining a sort per direction.
-        foreach ($sort_criteria as $sort) {
-            if ($sort->options['exposed'] == TRUE) {
-                $id = $sort->options['id'];
-                // Label should be translated via views already.
-                $label = $sort->options['expose']['label'];
-                $label = $this->t($label);
-                $asc = "{$id}_asc";
-                $desc = "{$id}_desc";
-                $options[$asc] = "{$label} ↓";
-                $options[$desc] = "{$label} ↑";
-                $options_attributes[$asc] = [
-                    'data-sort_by' => $id,
-                    'data-sort_order' => 'ASC',
-                ];
-                $options_attributes[$desc] = [
-                    'data-sort_by' => $id,
-                    'data-sort_order' => 'DESC',
-                ];
-            }
-        }
-        return [
-            '#type' => 'select',
-            '#title' => 'Sort',
-            '#title_display' => 'invisible',
-            '#options' => $options,
-            '#options_attributes' => $options_attributes,
-            '#attributes' => ['autocomplete' => 'off', "aria-label" => "Sort By"],
-            '#wrapper_attributes' => ['class' => ['pager__sort', 'container']],
-            '#name' => 'order',
-            '#value' => $default_value,
+      if ($config->get(SettingsForm::DISPLAY_GRID_FLAG) == 1) {
+        $display_options['grid'] = [
+          'icon' => 'fa-th',
+          'title' => $this->t('Grid'),
         ];
+      }
+      $active_display = $query_parameters['display'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getCacheMaxAge()
-    {
-        // The block cannot be cached, because it must always match the current
-        // search results.
-        return 0;
+    $items = [];
+    foreach ($display_options as $display => $options) {
+      $url = Url::fromRoute('<current>', [], [
+        'query' => array_merge($query_parameters, ['display' => $display]),
+        'absolute' => TRUE,
+      ]);
+      $text = "<i class='fa {$options['icon']}' aria-hidden='true'>&nbsp;</i><span class='display-mode'>{$options['title']}</span>";
+      $active = $active_display == $display;
+      $items[] = [
+        '#type' => 'link',
+        '#url' => $url,
+        '#title' => Markup::create($text),
+        '#attributes' => [
+          'class' => $active ?
+            ['pager__link', 'pager__link--is-active', 'pager__display'] :
+            ['pager__link', 'pager__display'],
+          'aria-label' => $this->t("Display as @link", ["@link" => Markup::create($text)]),
+          'type' => $display
+        ],
+        '#wrapper_attributes' => [
+          'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],
+        ],
+      ];
     }
+
+    if (count($items) > 0) {
+      return [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $items,
+        '#attributes' => [],
+        '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
+      ];
+    }
+    else {
+      return [
+        '#markup' => Markup::create('<span hidden id="override-default-display-mode">' . $active_display . '</span>'),
+        '#attributes' => [],
+        '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
+      ];
+    }
+  }
+
+  /**
+   * Build the sort by portion of the pager.
+   *
+   * @param array $sort_criteria
+   *   The search fields which can be sorted.
+   * @param array $query_parameters
+   *   The query parameters used to change the display format.
+   *
+   * @return array
+   *   A renderable array representing the sort by portion of pager.
+   */
+  protected function buildSortByForm(array $sort_criteria, array $query_parameters) {
+    $default_order = $query_parameters['sort_order'] ?? 'DESC';
+    $default_sort_by = $query_parameters['sort_by'] ?? 'search_api_relevance';
+    $default_value = $default_sort_by . '_' . strtolower($default_order);
+    $options = [];
+    $options_attributes = [];
+    // Not sure if this will work without defining a sort per direction.
+    foreach ($sort_criteria as $sort) {
+      if ($sort->options['exposed'] == TRUE) {
+        $id = $sort->options['id'];
+        // Label should be translated via views already.
+        $label = $sort->options['expose']['label'];
+        $label = $this->t($label);
+        $asc = "{$id}_asc";
+        $desc = "{$id}_desc";
+        $options[$asc] = "{$label} ↓";
+        $options[$desc] = "{$label} ↑";
+        $options_attributes[$asc] = [
+          'data-sort_by' => $id,
+          'data-sort_order' => 'ASC',
+        ];
+        $options_attributes[$desc] = [
+          'data-sort_by' => $id,
+          'data-sort_order' => 'DESC',
+        ];
+      }
+    }
+    return [
+      '#type' => 'select',
+      '#title' => 'Sort',
+      '#title_display' => 'invisible',
+      '#options' => $options,
+      '#options_attributes' => $options_attributes,
+      '#attributes' => ['autocomplete' => 'off', "aria-label" => "Sort By"],
+      '#wrapper_attributes' => ['class' => ['pager__sort', 'container']],
+      '#name' => 'order',
+      '#value' => $default_value,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    // The block cannot be cached, because it must always match the current
+    // search results.
+    return 0;
+  }
 
 }

--- a/src/Plugin/Block/SearchResultsPagerBlock.php
+++ b/src/Plugin/Block/SearchResultsPagerBlock.php
@@ -13,6 +13,7 @@ use Drupal\views\ViewExecutable;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Drupal\advanced_search\Form\SettingsForm;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Provides a 'AjaxViewBlock' block.
@@ -61,6 +62,58 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
       $plugin_definition,
       $container->get('request_stack')->getMainRequest()
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $config = \Drupal::config(SettingsForm::CONFIG_NAME);
+
+    $form['display-mode'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t("Pager Block"),
+      '#description' => $this->t("If this settings are set here, they will override the global settings at `/admin/config/search/advanced`")
+    ];
+    
+    $form['display-mode']['override_list_on_off'] = [
+      '#type' => 'checkbox',
+      '#title' => $this
+        ->t('Expose "List view" option.'),
+      '#default_value' => $this->configuration['override_list_on_off'] ?? $config->get(SettingsForm::DISPLAY_LIST_FLAG),
+    ];
+
+    $form['display-mode']['override_grid_on_off'] = [
+      '#type' => 'checkbox',
+      '#title' => $this
+        ->t('Expose "Grid view" option.'),
+      '#default_value' => $this->configuration['override_grid_on_off'] ?? $config->get(SettingsForm::DISPLAY_GRID_FLAG),
+    ];
+
+    $form['display-mode']['override-default-display-mode'] = [
+      '#type' => 'select',
+      '#title' => $this
+        ->t('Default view mode:'),
+      '#options' => [
+        'list' => 'List',
+        'grid' => 'Grid',
+      ],
+      '#default_value' => $this->configuration['override-default-display-mode'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT),
+    ];
+    
+    $form['#attributes']['class'][] = 'clearfix';
+    $form['#attached']['library'][] = 'advanced_search/advanced.search.admin';
+    return $form; 
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $values = $form_state->getValues();
+    $this->configuration["override_list_on_off"] = $values["display-mode"]['override_list_on_off'];
+    $this->configuration["override_grid_on_off"] = $values["display-mode"]['override_grid_on_off'];
+    $this->configuration["override-default-display-mode"] = $values["display-mode"]['override-default-display-mode'];
   }
 
   /**
@@ -219,21 +272,41 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
     $config = \Drupal::config(SettingsForm::CONFIG_NAME);
     $display_options = [];
 
-    if ($config->get(SettingsForm::DISPLAY_LIST_FLAG) == 1) {
-      $display_options['list'] = [
-        'icon' => 'fa-list',
-        'title' => $this->t('List'),
-      ];
+
+    if (isset($this->configuration["override_list_on_off"]) && isset($this->configuration["override_grid_on_off"])
+    && isset($this->configuration["override-default-display-mode"])) {
+      if ($this->configuration["override_list_on_off"] == 1) { 
+        $display_options['list'] = [
+          'icon' => 'fa-list',
+          'title' => $this->t('List'),
+        ];
+      } 
+
+      if ($this->configuration["override_grid_on_off"] == 1) { 
+        $display_options['grid'] = [
+          'icon' => 'fa-th',
+          'title' => $this->t('Grid'),
+        ];
+      }
+      $active_display = $query_parameters['display'] ?? $this->configuration["override-default-display-mode"];
+    }
+    else {
+      if ($config->get(SettingsForm::DISPLAY_LIST_FLAG) == 1) {
+        $display_options['list'] = [
+          'icon' => 'fa-list',
+          'title' => $this->t('List'),
+        ];
+      }
+
+      if ($config->get(SettingsForm::DISPLAY_GRID_FLAG) == 1) {
+        $display_options['grid'] = [
+          'icon' => 'fa-th',
+          'title' => $this->t('Grid'),
+        ];
+      }
+      $active_display = $query_parameters['display'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT);
     }
 
-    if ($config->get(SettingsForm::DISPLAY_GRID_FLAG) == 1) {
-      $display_options['grid'] = [
-        'icon' => 'fa-th',
-        'title' => $this->t('Grid'),
-      ];
-    }
-
-    $active_display = $query_parameters['display'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT);
     $items = [];
     foreach ($display_options as $display => $options) {
       $url = Url::fromRoute('<current>', [], [
@@ -258,13 +331,23 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
         ],
       ];
     }
-    return [
-      '#theme' => 'item_list',
-      '#list_type' => 'ul',
-      '#items' => $items,
-      '#attributes' => [],
-      '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
-    ];
+
+    if (count($items) > 0) {
+      return [
+        '#theme' => 'item_list',
+        '#list_type' => 'ul',
+        '#items' => $items,
+        '#attributes' => [],
+        '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
+      ];
+    }
+    else {
+      return [
+        '#markup' => Markup::create('<span hidden id="override-default-display-mode">' . $active_display . '</span>'),
+        '#attributes' => [],
+        '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
+      ];
+    }
   }
 
   /**

--- a/src/Plugin/Block/SearchResultsPagerBlock.php
+++ b/src/Plugin/Block/SearchResultsPagerBlock.php
@@ -25,389 +25,401 @@ use Drupal\Core\Form\FormStateInterface;
  *  category = @Translation("Islandora"),
  * )
  */
-class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPluginInterface {
-  use ViewAndDisplayIdentifiersTrait;
+class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPluginInterface
+{
+    use ViewAndDisplayIdentifiersTrait;
 
-  /**
-   * The clone of the current request object.
-   *
-   * @var \Symfony\Component\HttpFoundation\Request
-   */
-  protected $request;
+    /**
+     * The clone of the current request object.
+     *
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    protected $request;
 
-  /**
-   * Construct a FacetBlock instance.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param string $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Symfony\Component\HttpFoundation\Request $request
-   *   A request object for the current request.
-   */
-  final public function __construct(array $configuration, $plugin_id, $plugin_definition, Request $request) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->request = clone $request;
-  }
+    /**
+     * Construct a FacetBlock instance.
+     *
+     * @param array $configuration
+     *   A configuration array containing information about the plugin instance.
+     * @param string $plugin_id
+     *   The plugin_id for the plugin instance.
+     * @param string $plugin_definition
+     *   The plugin implementation definition.
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *   A request object for the current request.
+     */
+    final public function __construct(array $configuration, $plugin_id, $plugin_definition, Request $request)
+    {
+        parent::__construct($configuration, $plugin_id, $plugin_definition);
+        $this->request = clone $request;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('request_stack')->getMainRequest()
-    );
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition)
+    {
+        return new static(
+            $configuration,
+            $plugin_id,
+            $plugin_definition,
+            $container->get('request_stack')->getMainRequest()
+        );
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function blockForm($form, FormStateInterface $form_state) {
-    $config = \Drupal::config(SettingsForm::CONFIG_NAME);
+    /**
+     * {@inheritdoc}
+     */
+    public function blockForm($form, FormStateInterface $form_state)
+    {
+        $config = \Drupal::config(SettingsForm::CONFIG_NAME);
 
-    $form['display-mode'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t("Pager Block"),
-      '#description' => $this->t("If this settings are set here, they will override the global settings at `/admin/config/search/advanced`")
-    ];
-    
-    $form['display-mode']['override_list_on_off'] = [
-      '#type' => 'checkbox',
-      '#title' => $this
-        ->t('Expose "List view" option.'),
-      '#default_value' => $this->configuration['override_list_on_off'] ?? $config->get(SettingsForm::DISPLAY_LIST_FLAG),
-    ];
+        $form['display-mode'] = [
+            '#type' => 'fieldset',
+            '#title' => $this->t("Pager Block"),
+            '#description' => $this->t("If this settings are set here, they will override the global settings at `/admin/config/search/advanced`")
+        ];
 
-    $form['display-mode']['override_grid_on_off'] = [
-      '#type' => 'checkbox',
-      '#title' => $this
-        ->t('Expose "Grid view" option.'),
-      '#default_value' => $this->configuration['override_grid_on_off'] ?? $config->get(SettingsForm::DISPLAY_GRID_FLAG),
-    ];
+        $form['display-mode']['override_list_on_off'] = [
+            '#type' => 'checkbox',
+            '#title' => $this
+                ->t('Expose "List view" option.'),
+            '#default_value' => $this->configuration['override_list_on_off'] ?? $config->get(SettingsForm::DISPLAY_LIST_FLAG),
+        ];
 
-    $form['display-mode']['override-default-display-mode'] = [
-      '#type' => 'select',
-      '#title' => $this
-        ->t('Default view mode:'),
-      '#options' => [
-        'list' => 'List',
-        'grid' => 'Grid',
-      ],
-      '#default_value' => $this->configuration['override-default-display-mode'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT),
-    ];
-    
-    $form['#attributes']['class'][] = 'clearfix';
-    $form['#attached']['library'][] = 'advanced_search/advanced.search.admin';
-    return $form; 
-  }
+        $form['display-mode']['override_grid_on_off'] = [
+            '#type' => 'checkbox',
+            '#title' => $this
+                ->t('Expose "Grid view" option.'),
+            '#default_value' => $this->configuration['override_grid_on_off'] ?? $config->get(SettingsForm::DISPLAY_GRID_FLAG),
+        ];
 
-  /**
-   * {@inheritdoc}
-   */
-  public function blockSubmit($form, FormStateInterface $form_state) {
-    $values = $form_state->getValues();
-    $this->configuration["override_list_on_off"] = $values["display-mode"]['override_list_on_off'];
-    $this->configuration["override_grid_on_off"] = $values["display-mode"]['override_grid_on_off'];
-    $this->configuration["override-default-display-mode"] = $values["display-mode"]['override-default-display-mode'];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function build() {
-    $id = $this->getDerivativeId();
-    [$view_id, $display_id] = $this->getViewAndDisplayIdentifiers();
-    $view = View::Load($view_id);
-    $view_executable = $view->getExecutable();
-    $view_executable->setDisplay($display_id);
-    // Allow advanced search to alter the query.
-    $advanced_search_query = new AdvancedSearchQuery();
-    $advanced_search_query->alterView($this->request, $view_executable, $display_id);
-    $view_executable->execute();
-    $pager = $view_executable->getPager();
-    $exposed_input = $view_executable->getExposedInput();
-    $query_parameters = $this->request->query->all();
-    $build = [
-      '#attached' => [
-        'drupalSettings' => [
-          'advanced_search_pager_views_ajax' => [
-            $id => [
-              'view_id' => $view_id,
-              'current_display_id' => $display_id,
-              'ajax_path' => '/views/ajax',
+        $form['display-mode']['override-default-display-mode'] = [
+            '#type' => 'select',
+            '#title' => $this
+                ->t('Default view mode:'),
+            '#options' => [
+                'list' => 'List',
+                'grid' => 'Grid',
             ],
-          ],
-        ],
-      ],
-      '#attributes' => [
-        'class' => ['advanced_search_result_pager'],
-        'data-drupal-pager-id' => $id,
-      ],
-      'result_summary' => $this->buildResultsSummary($view_executable),
-      'container' => [
-        '#prefix' => '<div class="pager__group">',
-        '#suffix' => '</div>',
-        'results_per_page_links' => $this->buildResultsPerPageLinks($pager, $query_parameters),
-        'display_links' => $this->buildDisplayLinks($query_parameters),
-        'sort_by' => $this->buildSortByForm($view_executable->sort, $query_parameters),
-        'pager' => array_merge($pager->render($exposed_input), ['#wrapper_attributes' => ['class' => ['container']]]),
-      ],
-    ];
-    return $build;
-  }
-
-  /**
-   * Build the results summary portion of the pager.
-   *
-   * @param Drupal\views\ViewExecutable $view_executable
-   *   The view to build the summary for.
-   *
-   * @return array
-   *   A renderable array that represents the current page, and number of
-   *   results in the view.
-   */
-  protected function buildResultsSummary(ViewExecutable $view_executable) {
-    $current_page = (int) $view_executable->getCurrentPage() + 1;
-    $per_page = (int) $view_executable->getItemsPerPage();
-    $total = $view_executable->total_rows ?? count($view_executable->result);
-    // If there is no result the "start" and "current_record_count" should be
-    // equal to 0. To have the same calculation logic, we use a "start offset"
-    // to handle all the cases.
-    $start_offset = empty($total) ? 0 : 1;
-    if ($per_page === 0) {
-      $start = $start_offset;
-      $end = $total;
-    }
-    else {
-      $total_count = $current_page * $per_page;
-      if ($total_count > $total) {
-        $total_count = $total;
-      }
-      $start = ($current_page - 1) * $per_page + $start_offset;
-      $end = $total_count;
-    }
-    if (!empty($total)) {
-      // Return as render array.
-      return [
-        '#prefix' => '<div class="pager__summary">',
-        '#suffix' => '</div>',
-        '#markup' => $this->t('Displaying @start - @end of @total', [
-          '@start' => $start,
-          '@end' => $end,
-          '@total' => $total,
-        ]),
-      ];
-    }
-    return [];
-  }
-
-  /**
-   * Build the results per page portion of the pager.
-   *
-   * @param Drupal\views\Plugin\views\pager\SqlBase $pager
-   *   The pager for the view.
-   * @param array $query_parameters
-   *   The query parameters used to change the number of results per page.
-   *
-   * @return array
-   *   A renderable array representing the results per page portion of pager.
-   */
-  protected function buildResultsPerPageLinks(SqlBase $pager, array $query_parameters) {
-    $active_items_per_page = $query_parameters['items_per_page'] ?? $pager->options['items_per_page'];
-    $items_per_page_options = array_map(function ($value) {
-      return trim($value);
-    }, explode(',', $pager->options['expose']['items_per_page_options']));
-    $items = [];
-    foreach ($items_per_page_options as $items_per_page) {
-      $url = Url::fromRoute('<current>', [], [
-        // When changing the number of items displayed always return the user
-        // to the first page.
-        'query' => array_merge($query_parameters, [
-          'items_per_page' => $items_per_page,
-          'page' => 0,
-        ]),
-        'absolute' => TRUE,
-      ]);
-      $active = $items_per_page == $active_items_per_page;
-      $items[] = [
-        '#type' => 'link',
-        '#url' => $url,
-        '#title' => $items_per_page,
-        '#attributes' => [
-          'aria-label' => $this->t("@item items per page", ["@item" => $items_per_page]),
-          'class' => $active ?
-            ['pager__link', 'pager__link--is-active', 'pager__itemsperpage'] :
-            ['pager__link', 'pager__itemsperpage'],
-        ],
-        '#wrapper_attributes' => [
-          'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],
-        ],
-      ];
-    }
-    return [
-      '#theme' => 'item_list',
-      '#title' => $this->t('Results per page'),
-      '#list_type' => 'ul',
-      '#items' => $items,
-      '#attributes' => [],
-      '#wrapper_attributes' => ['class' => ['pager__results', 'container']],
-    ];
-  }
-
-  /**
-   * Build the display links portion of the pager (list/grid).
-   *
-   * @param array $query_parameters
-   *   The query parameters used to change the display format.
-   *
-   * @return array
-   *   A renderable array representing the display links portion of pager.
-   */
-  protected function buildDisplayLinks(array $query_parameters) {
-    $config = \Drupal::config(SettingsForm::CONFIG_NAME);
-    $display_options = [];
-
-
-    if (isset($this->configuration["override_list_on_off"]) && isset($this->configuration["override_grid_on_off"])
-    && isset($this->configuration["override-default-display-mode"])) {
-      if ($this->configuration["override_list_on_off"] == 1) { 
-        $display_options['list'] = [
-          'icon' => 'fa-list',
-          'title' => $this->t('List'),
+            '#default_value' => $this->configuration['override-default-display-mode'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT),
         ];
-      } 
 
-      if ($this->configuration["override_grid_on_off"] == 1) { 
-        $display_options['grid'] = [
-          'icon' => 'fa-th',
-          'title' => $this->t('Grid'),
+        $form['#attributes']['class'][] = 'clearfix';
+        $form['#attached']['library'][] = 'advanced_search/advanced.search.admin';
+        return $form;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function blockSubmit($form, FormStateInterface $form_state)
+    {
+        $values = $form_state->getValues();
+        $this->configuration["override_list_on_off"] = $values["display-mode"]['override_list_on_off'];
+        $this->configuration["override_grid_on_off"] = $values["display-mode"]['override_grid_on_off'];
+        $this->configuration["override-default-display-mode"] = $values["display-mode"]['override-default-display-mode'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build()
+    {
+        $id = $this->getDerivativeId();
+        [$view_id, $display_id] = $this->getViewAndDisplayIdentifiers();
+        $view = View::Load($view_id);
+        $view_executable = $view->getExecutable();
+        $view_executable->setDisplay($display_id);
+        // Allow advanced search to alter the query.
+        $advanced_search_query = new AdvancedSearchQuery();
+        $advanced_search_query->alterView($this->request, $view_executable, $display_id);
+        $view_executable->execute();
+        $pager = $view_executable->getPager();
+        $exposed_input = $view_executable->getExposedInput();
+        $query_parameters = $this->request->query->all();
+        $build = [
+            '#attached' => [
+                'drupalSettings' => [
+                    'advanced_search_pager_views_ajax' => [
+                        $id => [
+                            'view_id' => $view_id,
+                            'current_display_id' => $display_id,
+                            'ajax_path' => '/views/ajax',
+                        ],
+                    ],
+                ],
+            ],
+            '#attributes' => [
+                'class' => ['advanced_search_result_pager'],
+                'data-drupal-pager-id' => $id,
+            ],
+            'result_summary' => $this->buildResultsSummary($view_executable),
+            'container' => [
+                '#prefix' => '<div class="pager__group">',
+                '#suffix' => '</div>',
+                'results_per_page_links' => $this->buildResultsPerPageLinks($pager, $query_parameters),
+                'display_links' => $this->buildDisplayLinks($query_parameters),
+                'sort_by' => $this->buildSortByForm($view_executable->sort, $query_parameters),
+                'pager' => array_merge($pager->render($exposed_input), ['#wrapper_attributes' => ['class' => ['container']]]),
+            ],
         ];
-      }
-      $active_display = $query_parameters['display'] ?? $this->configuration["override-default-display-mode"];
+        return $build;
     }
-    else {
-      if ($config->get(SettingsForm::DISPLAY_LIST_FLAG) == 1) {
-        $display_options['list'] = [
-          'icon' => 'fa-list',
-          'title' => $this->t('List'),
+
+    /**
+     * Build the results summary portion of the pager.
+     *
+     * @param Drupal\views\ViewExecutable $view_executable
+     *   The view to build the summary for.
+     *
+     * @return array
+     *   A renderable array that represents the current page, and number of
+     *   results in the view.
+     */
+    protected function buildResultsSummary(ViewExecutable $view_executable)
+    {
+        $current_page = (int)$view_executable->getCurrentPage() + 1;
+        $per_page = (int)$view_executable->getItemsPerPage();
+        $total = $view_executable->total_rows ?? count($view_executable->result);
+        // If there is no result the "start" and "current_record_count" should be
+        // equal to 0. To have the same calculation logic, we use a "start offset"
+        // to handle all the cases.
+        $start_offset = empty($total) ? 0 : 1;
+        if ($per_page === 0) {
+            $start = $start_offset;
+            $end = $total;
+        } else {
+            $total_count = $current_page * $per_page;
+            if ($total_count > $total) {
+                $total_count = $total;
+            }
+            $start = ($current_page - 1) * $per_page + $start_offset;
+            $end = $total_count;
+        }
+        if (!empty($total)) {
+            // Return as render array.
+            return [
+                '#prefix' => '<div class="pager__summary">',
+                '#suffix' => '</div>',
+                '#markup' => $this->t('Displaying @start - @end of @total', [
+                    '@start' => $start,
+                    '@end' => $end,
+                    '@total' => $total,
+                ]),
+            ];
+        }
+        return [];
+    }
+
+    /**
+     * Build the results per page portion of the pager.
+     *
+     * @param Drupal\views\Plugin\views\pager\SqlBase $pager
+     *   The pager for the view.
+     * @param array $query_parameters
+     *   The query parameters used to change the number of results per page.
+     *
+     * @return array
+     *   A renderable array representing the results per page portion of pager.
+     */
+    protected function buildResultsPerPageLinks(SqlBase $pager, array $query_parameters)
+    {
+        $active_items_per_page = $query_parameters['items_per_page'] ?? $pager->options['items_per_page'];
+        $items_per_page_options = array_map(function ($value) {
+            return trim($value);
+        }, explode(',', $pager->options['expose']['items_per_page_options']));
+        $items = [];
+        foreach ($items_per_page_options as $items_per_page) {
+            $url = Url::fromRoute('<current>', [], [
+                // When changing the number of items displayed always return the user
+                // to the first page.
+                'query' => array_merge($query_parameters, [
+                    'items_per_page' => $items_per_page,
+                    'page' => 0,
+                ]),
+                'absolute' => TRUE,
+            ]);
+            $active = $items_per_page == $active_items_per_page;
+            $items[] = [
+                '#type' => 'link',
+                '#url' => $url,
+                '#title' => $items_per_page,
+                '#attributes' => [
+                    'aria-label' => $this->t("@item items per page", ["@item" => $items_per_page]),
+                    'class' => $active ?
+                        ['pager__link', 'pager__link--is-active', 'pager__itemsperpage'] :
+                        ['pager__link', 'pager__itemsperpage'],
+                ],
+                '#wrapper_attributes' => [
+                    'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],
+                ],
+            ];
+        }
+        return [
+            '#theme' => 'item_list',
+            '#title' => $this->t('Results per page'),
+            '#list_type' => 'ul',
+            '#items' => $items,
+            '#attributes' => [],
+            '#wrapper_attributes' => ['class' => ['pager__results', 'container']],
         ];
-      }
+    }
 
-      if ($config->get(SettingsForm::DISPLAY_GRID_FLAG) == 1) {
-        $display_options['grid'] = [
-          'icon' => 'fa-th',
-          'title' => $this->t('Grid'),
+    /**
+     * Build the display links portion of the pager (list/grid).
+     *
+     * @param array $query_parameters
+     *   The query parameters used to change the display format.
+     *
+     * @return array
+     *   A renderable array representing the display links portion of pager.
+     */
+    protected function buildDisplayLinks(array $query_parameters)
+    {
+        $config = \Drupal::config(SettingsForm::CONFIG_NAME);
+        $display_options = [];
+
+
+        if (isset($this->configuration["override_list_on_off"]) && isset($this->configuration["override_grid_on_off"])
+            && isset($this->configuration["override-default-display-mode"])) {
+            if ($this->configuration["override_list_on_off"] == 1) {
+                $display_options['list'] = [
+                    'icon' => 'fa-list',
+                    'title' => $this->t('List'),
+                ];
+            }
+
+            if ($this->configuration["override_grid_on_off"] == 1) {
+                $display_options['grid'] = [
+                    'icon' => 'fa-th',
+                    'title' => $this->t('Grid'),
+                ];
+            }
+            $active_display = $query_parameters['display'] ?? $this->configuration["override-default-display-mode"];
+        } else {
+            if ($config->get(SettingsForm::DISPLAY_LIST_FLAG) == 1) {
+                $display_options['list'] = [
+                    'icon' => 'fa-list',
+                    'title' => $this->t('List'),
+                ];
+            }
+
+            if ($config->get(SettingsForm::DISPLAY_GRID_FLAG) == 1) {
+                $display_options['grid'] = [
+                    'icon' => 'fa-th',
+                    'title' => $this->t('Grid'),
+                ];
+            }
+            $active_display = $query_parameters['display'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT);
+        }
+
+        $items = [];
+        foreach ($display_options as $display => $options) {
+            $url = Url::fromRoute('<current>', [], [
+                'query' => array_merge($query_parameters, ['display' => $display]),
+                'absolute' => TRUE,
+            ]);
+            $text = "<i class='fa {$options['icon']}' aria-hidden='true'>&nbsp;</i><span class='display-mode'>{$options['title']}</span>";
+            $active = $active_display == $display;
+            $items[] = [
+                '#type' => 'link',
+                '#url' => $url,
+                '#title' => Markup::create($text),
+                '#attributes' => [
+                    'class' => $active ?
+                        ['pager__link', 'pager__link--is-active', 'pager__display'] :
+                        ['pager__link', 'pager__display'],
+                    'aria-label' => $this->t("Display as @link", ["@link" => Markup::create($text)]),
+                    'type' => $display
+                ],
+                '#wrapper_attributes' => [
+                    'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],
+                ],
+            ];
+        }
+
+        if (count($items) > 0) {
+            return [
+                '#theme' => 'item_list',
+                '#list_type' => 'ul',
+                '#items' => $items,
+                '#attributes' => [],
+                '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
+            ];
+        } else {
+            return [
+                '#markup' => Markup::create('<span hidden id="override-default-display-mode">' . $active_display . '</span>'),
+                '#attributes' => [],
+                '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
+            ];
+        }
+    }
+
+    /**
+     * Build the sort by portion of the pager.
+     *
+     * @param array $sort_criteria
+     *   The search fields which can be sorted.
+     * @param array $query_parameters
+     *   The query parameters used to change the display format.
+     *
+     * @return array
+     *   A renderable array representing the sort by portion of pager.
+     */
+    protected function buildSortByForm(array $sort_criteria, array $query_parameters)
+    {
+        $default_order = $query_parameters['sort_order'] ?? 'DESC';
+        $default_sort_by = $query_parameters['sort_by'] ?? 'search_api_relevance';
+        $default_value = $default_sort_by . '_' . strtolower($default_order);
+        $options = [];
+        $options_attributes = [];
+        // Not sure if this will work without defining a sort per direction.
+        foreach ($sort_criteria as $sort) {
+            if ($sort->options['exposed'] == TRUE) {
+                $id = $sort->options['id'];
+                // Label should be translated via views already.
+                $label = $sort->options['expose']['label'];
+                $label = $this->t($label);
+                $asc = "{$id}_asc";
+                $desc = "{$id}_desc";
+                $options[$asc] = "{$label} ↓";
+                $options[$desc] = "{$label} ↑";
+                $options_attributes[$asc] = [
+                    'data-sort_by' => $id,
+                    'data-sort_order' => 'ASC',
+                ];
+                $options_attributes[$desc] = [
+                    'data-sort_by' => $id,
+                    'data-sort_order' => 'DESC',
+                ];
+            }
+        }
+        return [
+            '#type' => 'select',
+            '#title' => 'Sort',
+            '#title_display' => 'invisible',
+            '#options' => $options,
+            '#options_attributes' => $options_attributes,
+            '#attributes' => ['autocomplete' => 'off', "aria-label" => "Sort By"],
+            '#wrapper_attributes' => ['class' => ['pager__sort', 'container']],
+            '#name' => 'order',
+            '#value' => $default_value,
         ];
-      }
-      $active_display = $query_parameters['display'] ?? $config->get(SettingsForm::DISPLAY_DEFAULT);
     }
 
-    $items = [];
-    foreach ($display_options as $display => $options) {
-      $url = Url::fromRoute('<current>', [], [
-        'query' => array_merge($query_parameters, ['display' => $display]),
-        'absolute' => TRUE,
-      ]);
-      $text = "<i class='fa {$options['icon']}' aria-hidden='true'>&nbsp;</i><span class='display-mode'>{$options['title']}</span>";
-      $active = $active_display == $display;
-      $items[] = [
-        '#type' => 'link',
-        '#url' => $url,
-        '#title' => Markup::create($text),
-        '#attributes' => [
-          'class' => $active ?
-            ['pager__link', 'pager__link--is-active', 'pager__display'] :
-            ['pager__link', 'pager__display'],
-          'aria-label' => $this->t("Display as @link", ["@link" => Markup::create($text)]),
-          'type' => $display
-        ],
-        '#wrapper_attributes' => [
-          'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],
-        ],
-      ];
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheMaxAge()
+    {
+        // The block cannot be cached, because it must always match the current
+        // search results.
+        return 0;
     }
 
-    if (count($items) > 0) {
-      return [
-        '#theme' => 'item_list',
-        '#list_type' => 'ul',
-        '#items' => $items,
-        '#attributes' => [],
-        '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
-      ];
+    public function getDerivativeId()
+    {
+        // TODO: Implement getDerivativeId() method.
     }
-    else {
-      return [
-        '#markup' => Markup::create('<span hidden id="override-default-display-mode">' . $active_display . '</span>'),
-        '#attributes' => [],
-        '#wrapper_attributes' => ['class' => ['pager__display', 'container']],
-      ];
-    }
-  }
-
-  /**
-   * Build the sort by portion of the pager.
-   *
-   * @param array $sort_criteria
-   *   The search fields which can be sorted.
-   * @param array $query_parameters
-   *   The query parameters used to change the display format.
-   *
-   * @return array
-   *   A renderable array representing the sort by portion of pager.
-   */
-  protected function buildSortByForm(array $sort_criteria, array $query_parameters) {
-    $default_order = $query_parameters['sort_order'] ?? 'DESC';
-    $default_sort_by = $query_parameters['sort_by'] ?? 'search_api_relevance';
-    $default_value = $default_sort_by . '_' . strtolower($default_order);
-    $options = [];
-    $options_attributes = [];
-    // Not sure if this will work without defining a sort per direction.
-    foreach ($sort_criteria as $sort) {
-      if ($sort->options['exposed'] == TRUE) {
-        $id = $sort->options['id'];
-        // Label should be translated via views already.
-        $label = $sort->options['expose']['label'];
-        $label = $this->t($label);
-        $asc = "{$id}_asc";
-        $desc = "{$id}_desc";
-        $options[$asc] = "{$label} ↓";
-        $options[$desc] = "{$label} ↑";
-        $options_attributes[$asc] = [
-          'data-sort_by' => $id,
-          'data-sort_order' => 'ASC',
-        ];
-        $options_attributes[$desc] = [
-          'data-sort_by' => $id,
-          'data-sort_order' => 'DESC',
-        ];
-      }
-    }
-    return [
-      '#type' => 'select',
-      '#title' => 'Sort',
-      '#title_display' => 'invisible',
-      '#options' => $options,
-      '#options_attributes' => $options_attributes,
-      '#attributes' => ['autocomplete' => 'off', "aria-label" => "Sort By"],
-      '#wrapper_attributes' => ['class' => ['pager__sort', 'container']],
-      '#name' => 'order',
-      '#value' => $default_value,
-    ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getCacheMaxAge() {
-    // The block cannot be cached, because it must always match the current
-    // search results.
-    return 0;
-  }
-
 }

--- a/src/Plugin/Block/SearchResultsPagerBlock.php
+++ b/src/Plugin/Block/SearchResultsPagerBlock.php
@@ -418,8 +418,4 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
         return 0;
     }
 
-    public function getDerivativeId()
-    {
-        // TODO: Implement getDerivativeId() method.
-    }
 }


### PR DESCRIPTION
# What does this Pull Request do?
All of our users would prefer that 'Search within subcollections' be set to TRUE by default


# What's new?

 A new config.
 
 
# How should this be tested?

After updating the site should look exactly the same.  Navigate to https://islandora.dev/admin/config/search/advanced
and check the new box
<img width="912" height="196" alt="image" src="https://github.com/user-attachments/assets/8a9576aa-bd7d-432a-aa03-7a5bfbda08bf" />

Navigate to any page showing the advanced block and the include sub-collections box should already be checked
<img width="241" height="72" alt="image" src="https://github.com/user-attachments/assets/5dc372fc-f9ad-45ec-b823-4123018c088f" />

If the user unchecks the box, it should stay unchecked


# Documentation Status

Once merged documentation should be updated

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
