### PR TITLE
added back facet block override

### DIFF
--- a/advanced_search.module
+++ b/advanced_search.module
@@ -45,6 +45,9 @@ function advanced_search_library_info_alter(&$libraries, $extension) {
     $libraries['soft-limit']['js'] = [
       "$path/soft-limit.js" => [],
     ];
+    $libraries['drupal.facets.views-ajax']['js'] = [
+      "$path/facets-views-ajax.js" => [],
+    ];
   }
 }
 


### PR DESCRIPTION
# What does this Pull Request do?

The facet block override was removed here: https://github.com/Islandora/advanced_search/pull/71/files#diff-51dc8b4681103ee814368ae96df99836e97baf43f03754986d74f294ef9ecbffL48 but this caused ajax to spin indefinitely.

Putting this back should fix this issue: https://github.com/Islandora/advanced_search/issues/80

* **Related GitHub Issue**: [(link)](https://github.com/Islandora/advanced_search/issues/80)

* **Other Relevant Links**: (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# How should this be tested?

Import these changes and make sure that checkbox facets are working as intended

# Interested parties
@Islandora/committers
@kylehuynh205 
