### PR TITLE
Adding the translation for Items per page number links in Search Results Pager

### DIFF
--- a/js/facets/facets-views-ajax.js
+++ b/js/facets/facets-views-ajax.js
@@ -84,7 +84,7 @@
     if (url.indexOf("items_per_page=") == -1) { 
       // append items_per_page
       $("a.pager__itemsperpage").each(function( index ) {
-        var newUrl = url + "&items_per_page=" + $(this).html();
+        var newUrl = url + "&items_per_page=" + $(this).attr('itemsperpage');
         $(this).attr("href", newUrl);
       });
     } 
@@ -108,7 +108,7 @@
       }
       var newParamsUrl = newParams.join('&');
       $("a.pager__itemsperpage").each(function( index ) {
-        $(this).attr("href", url.split("?")[0] + '?' + newParamsUrl + "&items_per_page=" + $(this).html());
+        $(this).attr("href", url.split("?")[0] + '?' + newParamsUrl + "&items_per_page=" + $(this).attr('itemsperpage'));
       });
     }
 

--- a/src/Plugin/Block/SearchResultsPagerBlock.php
+++ b/src/Plugin/Block/SearchResultsPagerBlock.php
@@ -237,12 +237,13 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
       $items[] = [
         '#type' => 'link',
         '#url' => $url,
-        '#title' => $items_per_page,
+        '#title' => $this->t($items_per_page),
         '#attributes' => [
           'aria-label' => $this->t("@item items per page", ["@item" => $items_per_page]),
           'class' => $active ?
             ['pager__link', 'pager__link--is-active', 'pager__itemsperpage'] :
             ['pager__link', 'pager__itemsperpage'],
+ 	  "itemsperpage" => $items_per_page
         ],
         '#wrapper_attributes' => [
           'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],

--- a/src/Plugin/Block/SearchResultsPagerBlock.php
+++ b/src/Plugin/Block/SearchResultsPagerBlock.php
@@ -243,7 +243,7 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
           'class' => $active ?
             ['pager__link', 'pager__link--is-active', 'pager__itemsperpage'] :
             ['pager__link', 'pager__itemsperpage'],
- 	  "itemsperpage" => $items_per_page
+          'itemsperpage' => $items_per_page
         ],
         '#wrapper_attributes' => [
           'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],


### PR DESCRIPTION
# What does this Pull Request do?

Provide a brief description of what the intended result of the PR will be and/or what
 problem it solves.

* **Related GitHub Issue**: https://github.com/Islandora/advanced_search/issues/82

# What's new?
This PR added the translation for Items per page section in Search Results Pager: 

<img width="396" height="149" alt="Image" src="https://github.com/user-attachments/assets/4ad1d5e4-2902-41a1-abb1-f12fbaad3c41" />

# How should this be tested?

* Have isle-dc with `start_dev` or `starter` up running
* Add Arabic Language to the Drupal site 
* Go to Configuration > Region and language > User interface translation 
* Search for "15", "60", "120", then enter Arabic translation for those number. 
* Visit the search view: https://sandbox.islandora.ca/search
* Expect those number being translated as screenshot below: 

<img width="402" height="98" alt="Image" src="https://github.com/user-attachments/assets/ac2f2276-4253-4985-ac56-ca1217262d4e" />

* Click on the link of each number, expect the results display number items reflected on the selected number. 



