### PR TITLE
fix: resolve ajax errors on reset button click

### DIFF
--- a/js/advanced_search.form.js
+++ b/js/advanced_search.form.js
@@ -173,25 +173,34 @@
             });
           }
           // Reset should trigger refresh of AJAX Blocks / Views.
+          // Add a simple flag so we know that the user wants a reset.
+          let resetTriggered = false;
           $form.find('input[data-drupal-selector = "edit-reset"]').mousedown(function (e) {
-            const inputs = [];
-            const href = url(inputs, settings.advanced_search_form);
-            window.history.pushState(null, document.title, href.split('?')[0] );
-
-            /* reset the url after reset button clicked */
-            window.location.replace(href.split('?')[0]);
+            resetTriggered = true;
           });
-          
+
           // Handle the page summary
           $("#ajax-page-summary").hide();
-          $( document ).ajaxComplete(function( event, request, settings ) {
-              
+          $( document ).ajaxComplete(function( event, request, ajaxSettings ) {
               $("#ajax-page-summary").hide();
               if (jQuery("#ajax-page-summary").length >0) { 
                 $(".pager__summary").html($("#ajax-page-summary").html());
               }
               else {
                 $(".pager__summary").html("");
+              }
+
+              // After the ajax completes, see if the user wanted the reset.
+              if (resetTriggered){
+                const inputs = [];
+                const href = url(inputs, settings.advanced_search_form);
+
+                // Instead of using window.location.replace which causes full page to reload,
+                // Use pushState to update the URL without stopping any processes.
+                window.history.pushState(null, document.title, href.split('?')[0] );
+
+                // Reset the flag.
+                resetTriggered = false;
               }
           });
         }


### PR DESCRIPTION
Closes #87 

# What does this Pull Request do?
This PR resolves the errors visible in Firefox on the click of the **Reset** button on any **Advanced Search** view, by disabling full page reload which was terminating Ajax requests.

# What's new?
Changes made:
- Removed full page reload (```window.location.replace()```) which was terminating the Ajax request resulting in the errors described in issue #87 and instead added a flag which checks if the reset is triggered by clicking the **Reset button.**
- Changed from immediately handling the navigation/reload to waiting after the Ajax request completes, and then handling navigation if and only if the reset was triggered.
- Changed variable name from **settings** to **ajaxSettings** (for the ```ajaxComplete``` block) to match new logic. This is crucial because use of **settings** will imply using Ajax Settings from line 184 (```js/advanced_search.form.js```) instead of the intended use from line 101 (```js/advanced_search.form.js```).

* Does this change add any new dependencies?
**No**
* Does this change require any other modifications to be made to the repository (i.e. Regeneration activity, etc.)?
**No**
* Could this change impact execution of existing code?
**No, only the logic of execution is changed to solve the issue.**

# How should this be tested?
1. Open **Firefox** and go to your **Drupal site.**
2. Open the **Developer Tools console.**
3. Go to **Advanced Search view > Click the Reset button.**
4. You will observe that a **full page reload** is no longer happening and also the console will not have any errors.

# Documentation Status
* Does this change existing behaviour that's currently documented?
**No**
* Does this change require new pages or sections of documentation?
**No**

# Additional Notes:
N/A