### PR TITLE
feat: add no follow option in the links of Search Results Pager Block

### DIFF
--- a/config/schema/advanced_search.schema.yml
+++ b/config/schema/advanced_search.schema.yml
@@ -43,6 +43,9 @@ advanced_search.settings:
       sequence:
         type: string
         label: Field identifier
+    no_follow:
+      type: integer
+      label: Add rel="nofollow" attribute in links
 
 block.settings.search_block:
   type: block_settings

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -279,6 +279,9 @@ class SettingsForm extends ConfigFormBase {
       '#min' => 1,
     ];
 
+    /* -------------------------
+     * No follow option
+     * ------------------------- */
     $form['no-follow'] = [
       '#type' => 'fieldset',
       '#title' => $this->t("No Follow Block"),

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -60,6 +60,8 @@ class SettingsForm extends ConfigFormBase {
 
   const QUERY_FIELDS = 'query_fields';
 
+  const NO_FOLLOW = 'no_follow';
+
   /**
    * {@inheritdoc}
    */
@@ -277,6 +279,16 @@ class SettingsForm extends ConfigFormBase {
       '#min' => 1,
     ];
 
+    $form['no-follow'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t("No Follow Block"),
+    ];
+    $form['no-follow'][self::NO_FOLLOW] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Add rel="nofollow" attribute in links'),
+      '#default_value' => self::getConfig(self::NO_FOLLOW, 0),
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -300,6 +312,7 @@ class SettingsForm extends ConfigFormBase {
       ->set(self::DISPLAY_GRID_FLAG, $form_state->getValue(self::DISPLAY_GRID_FLAG))
       ->set(self::DISPLAY_DEFAULT, $form_state->getValue(self::DISPLAY_DEFAULT))
       ->set(self::QUERY_FIELDS, $query_fields)
+      ->set(self::NO_FOLLOW, $form_state->getValue(self::NO_FOLLOW))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/src/Plugin/Block/SearchResultsPagerBlock.php
+++ b/src/Plugin/Block/SearchResultsPagerBlock.php
@@ -236,6 +236,7 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
    *   A renderable array representing the results per page portion of pager.
    */
   protected function buildResultsPerPageLinks(SqlBase $pager, array $query_parameters) {
+    $config = $this->configFactory->get(SettingsForm::CONFIG_NAME);
     $active_items_per_page = $query_parameters['items_per_page'] ?? $pager->options['items_per_page'];
     $items_per_page_options = array_map(function ($value) {
       return trim($value);
@@ -252,12 +253,11 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
         'absolute' => TRUE,
       ]);
       $active = $items_per_page == $active_items_per_page;
-      $items[] = [
+      $item = [
         '#type' => 'link',
         '#url' => $url,
         '#title' => $items_per_page,
         '#attributes' => [
-          'rel' => $config->get(SettingsForm::NO_FOLLOW) == 1 ? 'nofollow' : '',
           'aria-label' => $this->t("@item items per page", ["@item" => $items_per_page]),
           'class' => $active ?
             ['pager__link', 'pager__link--is-active', 'pager__itemsperpage'] :
@@ -268,6 +268,10 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
           'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],
         ],
       ];
+      if (!empty($config->get(SettingsForm::NO_FOLLOW))) {
+        $item['#attributes']['rel'] = 'nofollow';
+      }
+      $items[] = $item;
     }
     return [
       '#theme' => 'item_list',
@@ -334,12 +338,11 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
       ]);
       $text = "<i class='fa {$options['icon']}' aria-hidden='true'>&nbsp;</i><span class='display-mode'>{$options['title']}</span>";
       $active = $active_display == $display;
-      $items[] = [
+      $item = [
         '#type' => 'link',
         '#url' => $url,
         '#title' => Markup::create($text),
         '#attributes' => [
-          'rel' => $config->get(SettingsForm::NO_FOLLOW) == 1 ? 'nofollow' : '',
           'class' => $active ?
             ['pager__link', 'pager__link--is-active', 'pager__display'] :
             ['pager__link', 'pager__display'],
@@ -350,6 +353,10 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
           'class' => $active ? ['pager__item', 'is-active'] : ['pager__item'],
         ],
       ];
+      if (!empty($config->get(SettingsForm::NO_FOLLOW))) {
+        $item['#attributes']['rel'] = 'nofollow';
+      }
+      $items[] = $item;
     }
 
     if (count($items) > 0) {

--- a/src/Plugin/Block/SearchResultsPagerBlock.php
+++ b/src/Plugin/Block/SearchResultsPagerBlock.php
@@ -257,6 +257,7 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
         '#url' => $url,
         '#title' => $items_per_page,
         '#attributes' => [
+          'rel' => $config->get(SettingsForm::NO_FOLLOW) == 1 ? 'nofollow' : '',
           'aria-label' => $this->t("@item items per page", ["@item" => $items_per_page]),
           'class' => $active ?
             ['pager__link', 'pager__link--is-active', 'pager__itemsperpage'] :
@@ -338,6 +339,7 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
         '#url' => $url,
         '#title' => Markup::create($text),
         '#attributes' => [
+          'rel' => $config->get(SettingsForm::NO_FOLLOW) == 1 ? 'nofollow' : '',
           'class' => $active ?
             ['pager__link', 'pager__link--is-active', 'pager__display'] :
             ['pager__link', 'pager__display'],


### PR DESCRIPTION
Closes #89 

# What does this Pull Request do?
This PR adds ```rel="nofollow"``` attribute to the links within the Search Results Pager block. It solves the problem of aggressive bot crawling and extensive resource consumption by allowing site administrators to signal to crawlers that they should not follow pagination links in search results.

# What's new?
This PR introduces a config form option to toggle ```rel="nofollow"``` link attributes in the Search Results Pager Block.
- Added a checkbox to the config form to allow users to toggle this behavior.
- Changed the link generation logic to conditionally inject the rel="nofollow" attribute based on the saved configuration setting.
- Does this change add any new dependencies? **No**.
- Does this change require any other modifications? **No**.
- Could this change impact execution of existing code? **No** (If the checkbox is left unchecked (default), the behavior remains identical to the current state)

# How should this be tested?
Enable:
1. Navigate to the config form for Advanced Search.
2. Check the new ```"Add rel="nofollow" attribute in Search Results Pager Block links"``` checkbox at the bottom of the page and save the configuration.
3. Verify Output:
 - Go to any page that contains the pager links as shown in the attached screenshot with this PR, OR perform a search.
 - Inspect the HTML source of the pager links.
 - Confirm that rel="nofollow" is present in the <a> tags.

Disable:
1. Go back to the config form, disable the checkbox, and save the configuration.
2. Reload the same page used for testing the enabling part.
3. Confirm that the ```rel="nofollow"``` attribute is no longer present in the pager links.

# Documentation Status
* Does this change existing behaviour that's currently documented? **No**. It adds an optional setting.
* Does this change require new pages or sections of documentation? A brief mention of the new configuration toggle in the Search Results block documentation would be beneficial.
* Who does this need to be documented for? **Developer, Systems Administrator** 

# Additional Notes:
Screenshot of the Search Results Pager links:
<img width="823" height="155" alt="Search Results Pager Links" src="https://github.com/user-attachments/assets/d7858190-a391-41fb-9fa4-2bbbb1d17af6" />

# Interested parties
@Islandora/committers
