### PR TITLE
fix: add missing dependencies to facets-views-ajax to fix infinite spinner

### DIFF
--- a/advanced_search.libraries.yml
+++ b/advanced_search.libraries.yml
@@ -21,4 +21,8 @@ advanced.search.pager:
 advanced.search.facets_views_ajax: 
   js: 
      js/facets/facets-views-ajax.js: {}
-
+  dependencies:
+    - core/drupal.ajax
+    - core/jquery
+    - core/once
+    - facets/drupal.facets.views-ajax


### PR DESCRIPTION
Closes #91 

# What does this Pull Request do?
This PR ensures that the `facets-views-ajax.js` library has the necessary dependencies to prevent the loading spinner from spinning infinitely during searches or facet clicks.

* **Other Relevant Links**: Issue #80, [Commit 90048f4](https://github.com/Islandora/advanced_search/commit/90048f4f77ff32ce5da1c4e207343efd6d460b61)

# What's new?
Updated `advanced_search.libraries.yml` to explicitly include the required dependencies for the `facets_views_ajax` library.
* Does this change add any new dependencies?  
Adds Drupal core and facets module dependencies
* Does this change require any other modifications to be made to the repository 
 (i.e. Regeneration activity, etc.)? 
No
* Could this change impact execution of existing code? 
No.

# How should this be tested?
To reproduce:
1. Use a site where the spinner loads infinitely (Example: [isle-dc at digitalutsc](https://github.com/digitalutsc/islandora_lite_docs/wiki/7.-Installation)).
2. Perform a search or click a facet.
3. Observer the spinner remaining on screen after results load.

After this fix:
1. Perform a search or click a facet.
2. The spinner should now dismiss immediately upon completion of the processing.

# Documentation Status
* Does this change existing behaviour that's currently documented?
No
* Does this change require new pages or sections of documentation?
No
* Who does this need to be documented for?
N/A

# Additional Notes:
This PR resolves a race condition where the custom JS would start before the AJAX and facets are fully initialized. So the script triggers the spinner and the search request, but it did not have the things required to process the response. Thus, as a result the spinner keeps spinning infinitely. By adding the dependencies, we now make sure that all the requirements are loading before the JS runs.
This way we keep the fix from [Commit 90048f4](https://github.com/Islandora/advanced_search/commit/90048f4f77ff32ce5da1c4e207343efd6d460b61) while ensuring it works for all environments. This fix has been tested on both our production, local and also Islandora Upstream starter site environment.

# Interested parties
@Islandora/committers
