### PR TITLE
Fix facets not reloading when browser back button is pressed

### DIFF
--- a/js/facets/facets-views-ajax.js
+++ b/js/facets/facets-views-ajax.js
@@ -180,9 +180,7 @@
   });
 
   window.addEventListener("popstate", function (e) {
-    if (e.state != null) {
       reload(window.location.href);
-    }
   });
 
   /**


### PR DESCRIPTION
**Problem**: Pressing the browser back button on a search page with facets updates the URL but doesn't reload the page, leaving facets stuck.

**Fix**: Removed the if (e.state != null) condition from the popstate event listener in facets-views-ajax.js so the page always reloads on back button press.
